### PR TITLE
feat: add many specific status code matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,62 @@ Additional expect matchers for http clients (e.g. Axios), supports `jest`, `vite
     - [.toHave3xxStatus()](#tohave3xxstatus) 
     - [.toHave4xxStatus()](#tohave4xxstatus)
     - [.toHave5xxStatus()](#tohave5xxstatus)
+    - [.toHaveSwitchingProtocolsStatus()](#tohaveswitchingprotocolsstatus)
+    - [.toHaveOkStatus()](#tohaveokstatus)
+    - [.toHaveCreatedStatus()](#tohavecreatedstatus)
+    - [.toHaveAcceptedStatus()](#tohaveacceptedstatus)
+    - [.toHaveNonAuthoritativeInformationStatus()](#tohavenonauthoritativeinformationstatus)
+    - [.toHaveNoContentStatus()](#tohavenocontentstatus)
+    - [.toHaveResetContentStatus()](#tohaveresetcontentstatus)
+    - [.toHavePartialContentStatus()](#tohavepartialcontentstatus)
+    - [.toHaveMultiStatusStatus()](#tohavemultistatusstatus)
+    - [.toHaveMultipleChoicesStatus()](#tohavemultiplechoicesstatus)
+    - [.toHaveMovedPermanentlyStatus()](#tohavemovedpermanentlystatus)
+    - [.toHaveMovedTemporarilyStatus()](#tohavemovedtemporarilystatus)
+    - [.toHaveSeeOtherStatus()](#tohaveseeotherstatus)
+    - [.toHaveNotModifiedStatus()](#tohavenotmodifiedstatus)
+    - [.toHaveUseProxyStatus()](#tohaveuseproxystatus)
+    - [.toHaveTemporaryRedirectStatus()](#tohavetemporaryredirectstatus)
+    - [.toHavePermanentRedirectStatus()](#tohavepermanentredirectstatus)
+    - [.toHaveBadRequestStatus()](#tohavebadrequeststatus)
+    - [.toHaveUnauthorizedStatus()](#tohaveunauthorizedstatus)
+    - [.toHavePaymentRequiredStatus()](#tohavepaymentrequiredstatus)
+    - [.toHaveForbiddenStatus()](#tohaveforbiddenstatus)
+    - [.toHaveNotFoundStatus()](#tohavenotfoundstatus)
+    - [.toHaveMethodNotAllowedStatus()](#tohavemethodnotallowedstatus)
+    - [.toHaveNotAcceptableStatus()](#tohavenotacceptablestatus)
+    - [.toHaveProxyAuthenticationRequiredStatus()](#tohaveproxyauthenticationrequiredstatus)
+    - [.toHaveRequestTimeoutStatus()](#tohaverequesttimeoutstatus)
+    - [.toHaveConflictStatus()](#tohaveconflictstatus)
+    - [.toHaveGoneStatus()](#tohavegonestatus)
+    - [.toHaveLengthRequiredStatus()](#tohavelengthrequiredstatus)
+    - [.toHavePreconditionFailedStatus()](#tohavepreconditionfailedstatus)
+    - [.toHaveRequestTooLongStatus()](#tohaverequesttoolongstatus)
+    - [.toHaveRequestUriTooLongStatus()](#tohaverequesturitoolongstatus)
+    - [.toHaveUnsupportedMediaTypeStatus()](#tohaveunsupportedmediatypestatus)
+    - [.toHaveRequestedRangeNotSatisfiableStatus()](#tohaverequestedrangenotsatisfiablestatus)
+    - [.toHaveExpectationFailedStatus()](#tohaveexpectationfailedstatus)
+    - [.toHaveImATeapotStatus()](#tohaveimateapotstatus)
+    - [.toHaveInsufficientSpaceOnResourceStatus()](#tohaveinsufficientspaceonresourcestatus)
+    - [.toHaveMethodFailureStatus()](#tohavemethodfailurestatus)
+    - [.toHaveMisdirectedRequestStatus()](#tohavemisdirectedrequeststatus)
+    - [.toHaveUnprocessableEntityStatus()](#tohaveunprocessableentitystatus)
+    - [.toHaveLockedStatus()](#tohavelockedstatus)
+    - [.toHaveFailedDependencyStatus()](#tohavefaileddependencystatus)
+    - [.toHaveUpgradeRequiredStatus()](#tohaveupgraderequiredstatus)
+    - [.toHavePreconditionRequiredStatus()](#tohavepreconditionrequiredstatus)
+    - [.toHaveTooManyRequestsStatus()](#tohavetoomanyrequestsstatus)
+    - [.toHaveRequestHeaderFieldsTooLargeStatus()](#tohaverequestheaderfieldstoolargestatus)
+    - [.toHaveUnavailableForLegalReasonsStatus()](#tohaveunavailableforlegalreasonsstatus)
+    - [.toHaveInternalServerErrorStatus()](#tohaveinternalservererrorstatus)
+    - [.toHaveNotImplementedStatus()](#tohavenotimplementedstatus)
+    - [.toHaveBadGatewayStatus()](#tohavebadgatewaystatus)
+    - [.toHaveServiceUnavailableStatus()](#tohaveserviceunavailablestatus)
+    - [.toHaveGatewayTimeoutStatus()](#tohavegatewaytimeoutstatus)
+    - [.toHaveHttpVersionNotSupportedStatus()](#tohavehttpversionnotsupportedstatus)
+    - [.toHaveInsufficientStorageStatus()](#tohaveinsufficientstoragestatus)
+    - [.toHaveNetworkAuthenticationRequiredStatus()](#tohavenetworkauthenticationrequiredstatus)
+
 
 ## Installation
 
@@ -293,6 +349,942 @@ test('passes when using .not.toHave5xxStatus() for 200', async () => {
     expect(response).not.toHave5xxStatus();
 });
 ```
+
+
+#### .toHaveSwitchingProtocolsStatus()
+
+Use `.toHaveSwitchingProtocolsStatus` when checking if HTTP response status code is SWITCHING_PROTOCOLS (101)
+
+```js
+test('passes when response have status code 101', async () => {
+    const response = await axios.get('https://httpstat.us/101');
+    expect(response).toHaveSwitchingProtocolsStatus();
+});
+
+test('passes when using .not.toHaveSwitchingProtocolsStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveSwitchingProtocolsStatus();
+});
+```
+
+
+#### .toHaveOkStatus()
+
+Use `.toHaveOkStatus` when checking if HTTP response status code is OK (200)
+
+```js
+test('passes when response have status code 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).toHaveOkStatus();
+});
+
+test('passes when using .not.toHaveOkStatus() for 400', async () => {
+    const response = await axios.get('https://httpstat.us/400');
+    expect(response).not.toHaveOkStatus();
+});
+```
+
+
+#### .toHaveCreatedStatus()
+
+Use `.toHaveCreatedStatus` when checking if HTTP response status code is CREATED (201)
+
+```js
+test('passes when response have status code 201', async () => {
+    const response = await axios.get('https://httpstat.us/201');
+    expect(response).toHaveCreatedStatus();
+});
+
+test('passes when using .not.toHaveCreatedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveCreatedStatus();
+});
+```
+
+
+#### .toHaveAcceptedStatus()
+
+Use `.toHaveAcceptedStatus` when checking if HTTP response status code is ACCEPTED (202)
+
+```js
+test('passes when response have status code 202', async () => {
+    const response = await axios.get('https://httpstat.us/202');
+    expect(response).toHaveAcceptedStatus();
+});
+
+test('passes when using .not.toHaveAcceptedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveAcceptedStatus();
+});
+```
+
+
+#### .toHaveNonAuthoritativeInformationStatus()
+
+Use `.toHaveNonAuthoritativeInformationStatus` when checking if HTTP response status code is NON_AUTHORITATIVE_INFORMATION (203)
+
+```js
+test('passes when response have status code 203', async () => {
+    const response = await axios.get('https://httpstat.us/203');
+    expect(response).toHaveNonAuthoritativeInformationStatus();
+});
+
+test('passes when using .not.toHaveNonAuthoritativeInformationStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveNonAuthoritativeInformationStatus();
+});
+```
+
+
+#### .toHaveNoContentStatus()
+
+Use `.toHaveNoContentStatus` when checking if HTTP response status code is NO_CONTENT (204)
+
+```js
+test('passes when response have status code 204', async () => {
+    const response = await axios.get('https://httpstat.us/204');
+    expect(response).toHaveNoContentStatus();
+});
+
+test('passes when using .not.toHaveNoContentStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveNoContentStatus();
+});
+```
+
+
+#### .toHaveResetContentStatus()
+
+Use `.toHaveResetContentStatus` when checking if HTTP response status code is RESET_CONTENT (205)
+
+```js
+test('passes when response have status code 205', async () => {
+    const response = await axios.get('https://httpstat.us/205');
+    expect(response).toHaveResetContentStatus();
+});
+
+test('passes when using .not.toHaveResetContentStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveResetContentStatus();
+});
+```
+
+
+#### .toHavePartialContentStatus()
+
+Use `.toHavePartialContentStatus` when checking if HTTP response status code is PARTIAL_CONTENT (206)
+
+```js
+test('passes when response have status code 206', async () => {
+    const response = await axios.get('https://httpstat.us/206');
+    expect(response).toHavePartialContentStatus();
+});
+
+test('passes when using .not.toHavePartialContentStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHavePartialContentStatus();
+});
+```
+
+
+#### .toHaveMultiStatusStatus()
+
+Use `.toHaveMultiStatusStatus` when checking if HTTP response status code is MULTI_STATUS (207)
+
+```js
+test('passes when response have status code 207', async () => {
+    const response = await axios.get('https://httpstat.us/207');
+    expect(response).toHaveMultiStatusStatus();
+});
+
+test('passes when using .not.toHaveMultiStatusStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveMultiStatusStatus();
+});
+```
+
+
+#### .toHaveMultipleChoicesStatus()
+
+Use `.toHaveMultipleChoicesStatus` when checking if HTTP response status code is MULTIPLE_CHOICES (300)
+
+```js
+test('passes when response have status code 300', async () => {
+    const response = await axios.get('https://httpstat.us/300');
+    expect(response).toHaveMultipleChoicesStatus();
+});
+
+test('passes when using .not.toHaveMultipleChoicesStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveMultipleChoicesStatus();
+});
+```
+
+
+#### .toHaveMovedPermanentlyStatus()
+
+Use `.toHaveMovedPermanentlyStatus` when checking if HTTP response status code is MOVED_PERMANENTLY (301)
+
+```js
+test('passes when response have status code 301', async () => {
+    const response = await axios.get('https://httpstat.us/301');
+    expect(response).toHaveMovedPermanentlyStatus();
+});
+
+test('passes when using .not.toHaveMovedPermanentlyStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveMovedPermanentlyStatus();
+});
+```
+
+
+#### .toHaveMovedTemporarilyStatus()
+
+Use `.toHaveMovedTemporarilyStatus` when checking if HTTP response status code is MOVED_TEMPORARILY (302)
+
+```js
+test('passes when response have status code 302', async () => {
+    const response = await axios.get('https://httpstat.us/302');
+    expect(response).toHaveMovedTemporarilyStatus();
+});
+
+test('passes when using .not.toHaveMovedTemporarilyStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveMovedTemporarilyStatus();
+});
+```
+
+
+#### .toHaveSeeOtherStatus()
+
+Use `.toHaveSeeOtherStatus` when checking if HTTP response status code is SEE_OTHER (303)
+
+```js
+test('passes when response have status code 303', async () => {
+    const response = await axios.get('https://httpstat.us/303');
+    expect(response).toHaveSeeOtherStatus();
+});
+
+test('passes when using .not.toHaveSeeOtherStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveSeeOtherStatus();
+});
+```
+
+
+#### .toHaveNotModifiedStatus()
+
+Use `.toHaveNotModifiedStatus` when checking if HTTP response status code is NOT_MODIFIED (304)
+
+```js
+test('passes when response have status code 304', async () => {
+    const response = await axios.get('https://httpstat.us/304');
+    expect(response).toHaveNotModifiedStatus();
+});
+
+test('passes when using .not.toHaveNotModifiedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveNotModifiedStatus();
+});
+```
+
+
+#### .toHaveUseProxyStatus()
+
+Use `.toHaveUseProxyStatus` when checking if HTTP response status code is USE_PROXY (305)
+
+```js
+test('passes when response have status code 305', async () => {
+    const response = await axios.get('https://httpstat.us/305');
+    expect(response).toHaveUseProxyStatus();
+});
+
+test('passes when using .not.toHaveUseProxyStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveUseProxyStatus();
+});
+```
+
+
+#### .toHaveTemporaryRedirectStatus()
+
+Use `.toHaveTemporaryRedirectStatus` when checking if HTTP response status code is TEMPORARY_REDIRECT (307)
+
+```js
+test('passes when response have status code 307', async () => {
+    const response = await axios.get('https://httpstat.us/307');
+    expect(response).toHaveTemporaryRedirectStatus();
+});
+
+test('passes when using .not.toHaveTemporaryRedirectStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveTemporaryRedirectStatus();
+});
+```
+
+
+#### .toHavePermanentRedirectStatus()
+
+Use `.toHavePermanentRedirectStatus` when checking if HTTP response status code is PERMANENT_REDIRECT (308)
+
+```js
+test('passes when response have status code 308', async () => {
+    const response = await axios.get('https://httpstat.us/308');
+    expect(response).toHavePermanentRedirectStatus();
+});
+
+test('passes when using .not.toHavePermanentRedirectStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHavePermanentRedirectStatus();
+});
+```
+
+
+#### .toHaveBadRequestStatus()
+
+Use `.toHaveBadRequestStatus` when checking if HTTP response status code is BAD_REQUEST (400)
+
+```js
+test('passes when response have status code 400', async () => {
+    const response = await axios.get('https://httpstat.us/400');
+    expect(response).toHaveBadRequestStatus();
+});
+
+test('passes when using .not.toHaveBadRequestStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveBadRequestStatus();
+});
+```
+
+
+#### .toHaveUnauthorizedStatus()
+
+Use `.toHaveUnauthorizedStatus` when checking if HTTP response status code is UNAUTHORIZED (401)
+
+```js
+test('passes when response have status code 401', async () => {
+    const response = await axios.get('https://httpstat.us/401');
+    expect(response).toHaveUnauthorizedStatus();
+});
+
+test('passes when using .not.toHaveUnauthorizedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveUnauthorizedStatus();
+});
+```
+
+
+#### .toHavePaymentRequiredStatus()
+
+Use `.toHavePaymentRequiredStatus` when checking if HTTP response status code is PAYMENT_REQUIRED (402)
+
+```js
+test('passes when response have status code 402', async () => {
+    const response = await axios.get('https://httpstat.us/402');
+    expect(response).toHavePaymentRequiredStatus();
+});
+
+test('passes when using .not.toHavePaymentRequiredStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHavePaymentRequiredStatus();
+});
+```
+
+
+#### .toHaveForbiddenStatus()
+
+Use `.toHaveForbiddenStatus` when checking if HTTP response status code is FORBIDDEN (403)
+
+```js
+test('passes when response have status code 403', async () => {
+    const response = await axios.get('https://httpstat.us/403');
+    expect(response).toHaveForbiddenStatus();
+});
+
+test('passes when using .not.toHaveForbiddenStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveForbiddenStatus();
+});
+```
+
+
+#### .toHaveNotFoundStatus()
+
+Use `.toHaveNotFoundStatus` when checking if HTTP response status code is NOT_FOUND (404)
+
+```js
+test('passes when response have status code 404', async () => {
+    const response = await axios.get('https://httpstat.us/404');
+    expect(response).toHaveNotFoundStatus();
+});
+
+test('passes when using .not.toHaveNotFoundStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveNotFoundStatus();
+});
+```
+
+
+#### .toHaveMethodNotAllowedStatus()
+
+Use `.toHaveMethodNotAllowedStatus` when checking if HTTP response status code is METHOD_NOT_ALLOWED (405)
+
+```js
+test('passes when response have status code 405', async () => {
+    const response = await axios.get('https://httpstat.us/405');
+    expect(response).toHaveMethodNotAllowedStatus();
+});
+
+test('passes when using .not.toHaveMethodNotAllowedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveMethodNotAllowedStatus();
+});
+```
+
+
+#### .toHaveNotAcceptableStatus()
+
+Use `.toHaveNotAcceptableStatus` when checking if HTTP response status code is NOT_ACCEPTABLE (406)
+
+```js
+test('passes when response have status code 406', async () => {
+    const response = await axios.get('https://httpstat.us/406');
+    expect(response).toHaveNotAcceptableStatus();
+});
+
+test('passes when using .not.toHaveNotAcceptableStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveNotAcceptableStatus();
+});
+```
+
+
+#### .toHaveProxyAuthenticationRequiredStatus()
+
+Use `.toHaveProxyAuthenticationRequiredStatus` when checking if HTTP response status code is PROXY_AUTHENTICATION_REQUIRED (407)
+
+```js
+test('passes when response have status code 407', async () => {
+    const response = await axios.get('https://httpstat.us/407');
+    expect(response).toHaveProxyAuthenticationRequiredStatus();
+});
+
+test('passes when using .not.toHaveProxyAuthenticationRequiredStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveProxyAuthenticationRequiredStatus();
+});
+```
+
+
+#### .toHaveRequestTimeoutStatus()
+
+Use `.toHaveRequestTimeoutStatus` when checking if HTTP response status code is REQUEST_TIMEOUT (408)
+
+```js
+test('passes when response have status code 408', async () => {
+    const response = await axios.get('https://httpstat.us/408');
+    expect(response).toHaveRequestTimeoutStatus();
+});
+
+test('passes when using .not.toHaveRequestTimeoutStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveRequestTimeoutStatus();
+});
+```
+
+
+#### .toHaveConflictStatus()
+
+Use `.toHaveConflictStatus` when checking if HTTP response status code is CONFLICT (409)
+
+```js
+test('passes when response have status code 409', async () => {
+    const response = await axios.get('https://httpstat.us/409');
+    expect(response).toHaveConflictStatus();
+});
+
+test('passes when using .not.toHaveConflictStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveConflictStatus();
+});
+```
+
+
+#### .toHaveGoneStatus()
+
+Use `.toHaveGoneStatus` when checking if HTTP response status code is GONE (410)
+
+```js
+test('passes when response have status code 410', async () => {
+    const response = await axios.get('https://httpstat.us/410');
+    expect(response).toHaveGoneStatus();
+});
+
+test('passes when using .not.toHaveGoneStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveGoneStatus();
+});
+```
+
+
+#### .toHaveLengthRequiredStatus()
+
+Use `.toHaveLengthRequiredStatus` when checking if HTTP response status code is LENGTH_REQUIRED (411)
+
+```js
+test('passes when response have status code 411', async () => {
+    const response = await axios.get('https://httpstat.us/411');
+    expect(response).toHaveLengthRequiredStatus();
+});
+
+test('passes when using .not.toHaveLengthRequiredStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveLengthRequiredStatus();
+});
+```
+
+
+#### .toHavePreconditionFailedStatus()
+
+Use `.toHavePreconditionFailedStatus` when checking if HTTP response status code is PRECONDITION_FAILED (412)
+
+```js
+test('passes when response have status code 412', async () => {
+    const response = await axios.get('https://httpstat.us/412');
+    expect(response).toHavePreconditionFailedStatus();
+});
+
+test('passes when using .not.toHavePreconditionFailedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHavePreconditionFailedStatus();
+});
+```
+
+
+#### .toHaveRequestTooLongStatus()
+
+Use `.toHaveRequestTooLongStatus` when checking if HTTP response status code is REQUEST_TOO_LONG (413)
+
+```js
+test('passes when response have status code 413', async () => {
+    const response = await axios.get('https://httpstat.us/413');
+    expect(response).toHaveRequestTooLongStatus();
+});
+
+test('passes when using .not.toHaveRequestTooLongStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveRequestTooLongStatus();
+});
+```
+
+
+#### .toHaveRequestUriTooLongStatus()
+
+Use `.toHaveRequestUriTooLongStatus` when checking if HTTP response status code is REQUEST_URI_TOO_LONG (414)
+
+```js
+test('passes when response have status code 414', async () => {
+    const response = await axios.get('https://httpstat.us/414');
+    expect(response).toHaveRequestUriTooLongStatus();
+});
+
+test('passes when using .not.toHaveRequestUriTooLongStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveRequestUriTooLongStatus();
+});
+```
+
+
+#### .toHaveUnsupportedMediaTypeStatus()
+
+Use `.toHaveUnsupportedMediaTypeStatus` when checking if HTTP response status code is UNSUPPORTED_MEDIA_TYPE (415)
+
+```js
+test('passes when response have status code 415', async () => {
+    const response = await axios.get('https://httpstat.us/415');
+    expect(response).toHaveUnsupportedMediaTypeStatus();
+});
+
+test('passes when using .not.toHaveUnsupportedMediaTypeStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveUnsupportedMediaTypeStatus();
+});
+```
+
+
+#### .toHaveRequestedRangeNotSatisfiableStatus()
+
+Use `.toHaveRequestedRangeNotSatisfiableStatus` when checking if HTTP response status code is REQUESTED_RANGE_NOT_SATISFIABLE (416)
+
+```js
+test('passes when response have status code 416', async () => {
+    const response = await axios.get('https://httpstat.us/416');
+    expect(response).toHaveRequestedRangeNotSatisfiableStatus();
+});
+
+test('passes when using .not.toHaveRequestedRangeNotSatisfiableStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveRequestedRangeNotSatisfiableStatus();
+});
+```
+
+
+#### .toHaveExpectationFailedStatus()
+
+Use `.toHaveExpectationFailedStatus` when checking if HTTP response status code is EXPECTATION_FAILED (417)
+
+```js
+test('passes when response have status code 417', async () => {
+    const response = await axios.get('https://httpstat.us/417');
+    expect(response).toHaveExpectationFailedStatus();
+});
+
+test('passes when using .not.toHaveExpectationFailedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveExpectationFailedStatus();
+});
+```
+
+
+#### .toHaveImATeapotStatus()
+
+Use `.toHaveImATeapotStatus` when checking if HTTP response status code is IM_A_TEAPOT (418)
+
+```js
+test('passes when response have status code 418', async () => {
+    const response = await axios.get('https://httpstat.us/418');
+    expect(response).toHaveImATeapotStatus();
+});
+
+test('passes when using .not.toHaveImATeapotStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveImATeapotStatus();
+});
+```
+
+
+#### .toHaveInsufficientSpaceOnResourceStatus()
+
+Use `.toHaveInsufficientSpaceOnResourceStatus` when checking if HTTP response status code is INSUFFICIENT_SPACE_ON_RESOURCE (419)
+
+```js
+test('passes when response have status code 419', async () => {
+    const response = await axios.get('https://httpstat.us/419');
+    expect(response).toHaveInsufficientSpaceOnResourceStatus();
+});
+
+test('passes when using .not.toHaveInsufficientSpaceOnResourceStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveInsufficientSpaceOnResourceStatus();
+});
+```
+
+
+#### .toHaveMethodFailureStatus()
+
+Use `.toHaveMethodFailureStatus` when checking if HTTP response status code is METHOD_FAILURE (420)
+
+```js
+test('passes when response have status code 420', async () => {
+    const response = await axios.get('https://httpstat.us/420');
+    expect(response).toHaveMethodFailureStatus();
+});
+
+test('passes when using .not.toHaveMethodFailureStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveMethodFailureStatus();
+});
+```
+
+
+#### .toHaveMisdirectedRequestStatus()
+
+Use `.toHaveMisdirectedRequestStatus` when checking if HTTP response status code is MISDIRECTED_REQUEST (421)
+
+```js
+test('passes when response have status code 421', async () => {
+    const response = await axios.get('https://httpstat.us/421');
+    expect(response).toHaveMisdirectedRequestStatus();
+});
+
+test('passes when using .not.toHaveMisdirectedRequestStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveMisdirectedRequestStatus();
+});
+```
+
+
+#### .toHaveUnprocessableEntityStatus()
+
+Use `.toHaveUnprocessableEntityStatus` when checking if HTTP response status code is UNPROCESSABLE_ENTITY (422)
+
+```js
+test('passes when response have status code 422', async () => {
+    const response = await axios.get('https://httpstat.us/422');
+    expect(response).toHaveUnprocessableEntityStatus();
+});
+
+test('passes when using .not.toHaveUnprocessableEntityStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveUnprocessableEntityStatus();
+});
+```
+
+
+#### .toHaveLockedStatus()
+
+Use `.toHaveLockedStatus` when checking if HTTP response status code is LOCKED (423)
+
+```js
+test('passes when response have status code 423', async () => {
+    const response = await axios.get('https://httpstat.us/423');
+    expect(response).toHaveLockedStatus();
+});
+
+test('passes when using .not.toHaveLockedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveLockedStatus();
+});
+```
+
+
+#### .toHaveFailedDependencyStatus()
+
+Use `.toHaveFailedDependencyStatus` when checking if HTTP response status code is FAILED_DEPENDENCY (424)
+
+```js
+test('passes when response have status code 424', async () => {
+    const response = await axios.get('https://httpstat.us/424');
+    expect(response).toHaveFailedDependencyStatus();
+});
+
+test('passes when using .not.toHaveFailedDependencyStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveFailedDependencyStatus();
+});
+```
+
+
+#### .toHaveUpgradeRequiredStatus()
+
+Use `.toHaveUpgradeRequiredStatus` when checking if HTTP response status code is UPGRADE_REQUIRED (426)
+
+```js
+test('passes when response have status code 426', async () => {
+    const response = await axios.get('https://httpstat.us/426');
+    expect(response).toHaveUpgradeRequiredStatus();
+});
+
+test('passes when using .not.toHaveUpgradeRequiredStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveUpgradeRequiredStatus();
+});
+```
+
+
+#### .toHavePreconditionRequiredStatus()
+
+Use `.toHavePreconditionRequiredStatus` when checking if HTTP response status code is PRECONDITION_REQUIRED (428)
+
+```js
+test('passes when response have status code 428', async () => {
+    const response = await axios.get('https://httpstat.us/428');
+    expect(response).toHavePreconditionRequiredStatus();
+});
+
+test('passes when using .not.toHavePreconditionRequiredStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHavePreconditionRequiredStatus();
+});
+```
+
+
+#### .toHaveTooManyRequestsStatus()
+
+Use `.toHaveTooManyRequestsStatus` when checking if HTTP response status code is TOO_MANY_REQUESTS (429)
+
+```js
+test('passes when response have status code 429', async () => {
+    const response = await axios.get('https://httpstat.us/429');
+    expect(response).toHaveTooManyRequestsStatus();
+});
+
+test('passes when using .not.toHaveTooManyRequestsStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveTooManyRequestsStatus();
+});
+```
+
+
+#### .toHaveRequestHeaderFieldsTooLargeStatus()
+
+Use `.toHaveRequestHeaderFieldsTooLargeStatus` when checking if HTTP response status code is REQUEST_HEADER_FIELDS_TOO_LARGE (431)
+
+```js
+test('passes when response have status code 431', async () => {
+    const response = await axios.get('https://httpstat.us/431');
+    expect(response).toHaveRequestHeaderFieldsTooLargeStatus();
+});
+
+test('passes when using .not.toHaveRequestHeaderFieldsTooLargeStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveRequestHeaderFieldsTooLargeStatus();
+});
+```
+
+
+#### .toHaveUnavailableForLegalReasonsStatus()
+
+Use `.toHaveUnavailableForLegalReasonsStatus` when checking if HTTP response status code is UNAVAILABLE_FOR_LEGAL_REASONS (451)
+
+```js
+test('passes when response have status code 451', async () => {
+    const response = await axios.get('https://httpstat.us/451');
+    expect(response).toHaveUnavailableForLegalReasonsStatus();
+});
+
+test('passes when using .not.toHaveUnavailableForLegalReasonsStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveUnavailableForLegalReasonsStatus();
+});
+```
+
+
+#### .toHaveInternalServerErrorStatus()
+
+Use `.toHaveInternalServerErrorStatus` when checking if HTTP response status code is INTERNAL_SERVER_ERROR (500)
+
+```js
+test('passes when response have status code 500', async () => {
+    const response = await axios.get('https://httpstat.us/500');
+    expect(response).toHaveInternalServerErrorStatus();
+});
+
+test('passes when using .not.toHaveInternalServerErrorStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveInternalServerErrorStatus();
+});
+```
+
+
+#### .toHaveNotImplementedStatus()
+
+Use `.toHaveNotImplementedStatus` when checking if HTTP response status code is NOT_IMPLEMENTED (501)
+
+```js
+test('passes when response have status code 501', async () => {
+    const response = await axios.get('https://httpstat.us/501');
+    expect(response).toHaveNotImplementedStatus();
+});
+
+test('passes when using .not.toHaveNotImplementedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveNotImplementedStatus();
+});
+```
+
+
+#### .toHaveBadGatewayStatus()
+
+Use `.toHaveBadGatewayStatus` when checking if HTTP response status code is BAD_GATEWAY (502)
+
+```js
+test('passes when response have status code 502', async () => {
+    const response = await axios.get('https://httpstat.us/502');
+    expect(response).toHaveBadGatewayStatus();
+});
+
+test('passes when using .not.toHaveBadGatewayStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveBadGatewayStatus();
+});
+```
+
+
+#### .toHaveServiceUnavailableStatus()
+
+Use `.toHaveServiceUnavailableStatus` when checking if HTTP response status code is SERVICE_UNAVAILABLE (503)
+
+```js
+test('passes when response have status code 503', async () => {
+    const response = await axios.get('https://httpstat.us/503');
+    expect(response).toHaveServiceUnavailableStatus();
+});
+
+test('passes when using .not.toHaveServiceUnavailableStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveServiceUnavailableStatus();
+});
+```
+
+
+#### .toHaveGatewayTimeoutStatus()
+
+Use `.toHaveGatewayTimeoutStatus` when checking if HTTP response status code is GATEWAY_TIMEOUT (504)
+
+```js
+test('passes when response have status code 504', async () => {
+    const response = await axios.get('https://httpstat.us/504');
+    expect(response).toHaveGatewayTimeoutStatus();
+});
+
+test('passes when using .not.toHaveGatewayTimeoutStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveGatewayTimeoutStatus();
+});
+```
+
+
+#### .toHaveHttpVersionNotSupportedStatus()
+
+Use `.toHaveHttpVersionNotSupportedStatus` when checking if HTTP response status code is HTTP_VERSION_NOT_SUPPORTED (505)
+
+```js
+test('passes when response have status code 505', async () => {
+    const response = await axios.get('https://httpstat.us/505');
+    expect(response).toHaveHttpVersionNotSupportedStatus();
+});
+
+test('passes when using .not.toHaveHttpVersionNotSupportedStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveHttpVersionNotSupportedStatus();
+});
+```
+
+
+#### .toHaveInsufficientStorageStatus()
+
+Use `.toHaveInsufficientStorageStatus` when checking if HTTP response status code is INSUFFICIENT_STORAGE (507)
+
+```js
+test('passes when response have status code 507', async () => {
+    const response = await axios.get('https://httpstat.us/507');
+    expect(response).toHaveInsufficientStorageStatus();
+});
+
+test('passes when using .not.toHaveInsufficientStorageStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveInsufficientStorageStatus();
+});
+```
+
+
+#### .toHaveNetworkAuthenticationRequiredStatus()
+
+Use `.toHaveNetworkAuthenticationRequiredStatus` when checking if HTTP response status code is NETWORK_AUTHENTICATION_REQUIRED (511)
+
+```js
+test('passes when response have status code 511', async () => {
+    const response = await axios.get('https://httpstat.us/511');
+    expect(response).toHaveNetworkAuthenticationRequiredStatus();
+});
+
+test('passes when using .not.toHaveNetworkAuthenticationRequiredStatus() for 200', async () => {
+    const response = await axios.get('https://httpstat.us/200');
+    expect(response).not.toHaveNetworkAuthenticationRequiredStatus();
+});
+```
+
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ axios.defaults.validateStatus = () => true;
 
 same as [`.toHave2xxStatus`](#tohave2xxstatus)
 
-Use `.toBeSuccessful` when checking if Axios response status code is between 200 and 299 (included)
+Use `.toBeSuccessful` when checking if response status code is between 200 and 299 (included)
 
 ```js
 test('passes when response have status code 200', async () => {
@@ -232,7 +232,7 @@ test('passes when using .not.toBeSuccessful() for 404', async () => {
 
 same as [`.toBeSuccessful`](#tobesuccessful)
 
-Use `.toHave2xxStatus` when checking if Axios response status code is between 200 and 299 (included)
+Use `.toHave2xxStatus` when checking if response status code is between 200 and 299 (included)
 
 ```js
 test('passes when response have status code 200', async () => {
@@ -248,7 +248,7 @@ test('passes when using .not.toHave2xxStatus() for 404', async () => {
 
 #### .toHave3xxStatus()
 
-Use `.toHave3xxStatus` when checking if Axios response status code is between 300 and 399 (included)
+Use `.toHave3xxStatus` when checking if response status code is between 300 and 399 (included)
 
 ```js
 test('passes when response have status code 300', async () => {
@@ -264,7 +264,7 @@ test('passes when using .not.toHave3xxStatus() for 200', async () => {
 
 #### .toHave4xxStatus()
 
-Use `.toHave4xxStatus` when checking if Axios response status code is between 400 and 499 (included)
+Use `.toHave4xxStatus` when checking if response status code is between 400 and 499 (included)
 
 ```js
 test('passes when response have status code 400', async () => {
@@ -280,7 +280,7 @@ test('passes when using .not.toHave4xxStatus() for 200', async () => {
 
 #### .toHave5xxStatus()
 
-Use `.toHave5xxStatus` when checking if Axios response status code is between 500 and 599 (included)
+Use `.toHave5xxStatus` when checking if response status code is between 500 and 599 (included)
 
 ```js
 test('passes when response have status code 500', async () => {

--- a/all.js
+++ b/all.js
@@ -6,7 +6,7 @@ if (globalExpect !== undefined) {
 } else {
   throw new Error(
     'Unable to find global expect. ' +
-      'Please check you have added expect-axios-matchers correctly.' +
-      'See https://github.com/Tamir-M/expect-axios-matchers#setup for help.',
+      'Please check you have added expect-http-client-matchers correctly.' +
+      'See https://github.com/Tamir-M/expect-http-client-matchers#setup for help.',
   );
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,22 @@
   "name": "expect-http-client-matchers",
   "version": "0.0.0-development",
   "description": "expect matchers for http-client responses (e.g. axios)",
-  "keywords": ["test", "unittest", "integration test", "mocha", "vitest", "expect"],
-  "files": ["src", "types", "all.js", "jest.d.ts", "expect.d.ts", "vitest.d.ts"],
+  "keywords": [
+    "test",
+    "unittest",
+    "integration test",
+    "mocha",
+    "vitest",
+    "expect"
+  ],
+  "files": [
+    "src",
+    "types",
+    "all.js",
+    "jest.d.ts",
+    "expect.d.ts",
+    "vitest.d.ts"
+  ],
   "main": "src/index.js",
   "typings": "types/index.d.ts",
   "scripts": {
@@ -41,7 +55,9 @@
     "access": "public"
   },
   "release": {
-    "branches": ["master"]
+    "branches": [
+      "master"
+    ]
   },
   "repository": {
     "type": "git",
@@ -50,5 +66,10 @@
   "bugs": {
     "url": "https://github.com/Tamir-M/expect-http-client-matchers/issues"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "change-case": "^5.4.4",
+    "enum-values": "^1.2.1",
+    "http-status-codes": "^2.3.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,22 +2,8 @@
   "name": "expect-http-client-matchers",
   "version": "0.0.0-development",
   "description": "expect matchers for http-client responses (e.g. axios)",
-  "keywords": [
-    "test",
-    "unittest",
-    "integration test",
-    "mocha",
-    "vitest",
-    "expect"
-  ],
-  "files": [
-    "src",
-    "types",
-    "all.js",
-    "jest.d.ts",
-    "expect.d.ts",
-    "vitest.d.ts"
-  ],
+  "keywords": ["test", "unittest", "integration test", "mocha", "vitest", "expect"],
+  "files": ["src", "types", "all.js", "jest.d.ts", "expect.d.ts", "vitest.d.ts"],
   "main": "src/index.js",
   "typings": "types/index.d.ts",
   "scripts": {
@@ -55,9 +41,7 @@
     "access": "public"
   },
   "release": {
-    "branches": [
-      "master"
-    ]
+    "branches": ["master"]
   },
   "repository": {
     "type": "git",

--- a/src/matchers/status/generic/toHave2xxStatus.js
+++ b/src/matchers/status/generic/toHave2xxStatus.js
@@ -1,11 +1,6 @@
 const { printDebugInfo } = require('../../../utils/get-debug-info');
 const { getMatchingAdapter } = require('../../../http-clients');
 
-/**
- * this matcher expects axios response to have 2xx status.
- * @param {import('axios').AxiosResponse} expected
- * @returns {{pass: boolean, message: (function(): string)}}
- */
 function toHave2xxStatus(expected) {
   const { matcherHint, printReceived } = this.utils;
 

--- a/src/matchers/status/generic/toHave3xxStatus.js
+++ b/src/matchers/status/generic/toHave3xxStatus.js
@@ -1,11 +1,6 @@
 const { printDebugInfo } = require('../../../utils/get-debug-info');
 const { getMatchingAdapter } = require('../../../http-clients');
 
-/**
- * this matcher expects axios response to have 3xx status.
- * @param {import('axios').AxiosResponse} expected
- * @returns {{pass: boolean, message: (function(): string)}}
- */
 function toHave3xxStatus(expected) {
   const { matcherHint, printReceived } = this.utils;
 

--- a/src/matchers/status/generic/toHave4xxStatus.js
+++ b/src/matchers/status/generic/toHave4xxStatus.js
@@ -1,11 +1,6 @@
 const { printDebugInfo } = require('../../../utils/get-debug-info');
 const { getMatchingAdapter } = require('../../../http-clients');
 
-/**
- * this matcher expects axios response to have 4xx status.
- * @param {import('axios').AxiosResponse} expected
- * @returns {{pass: boolean, message: (function(): string)}}
- */
 function toHave4xxStatus(expected) {
   const { matcherHint, printReceived } = this.utils;
 

--- a/src/matchers/status/generic/toHave5xxStatus.js
+++ b/src/matchers/status/generic/toHave5xxStatus.js
@@ -1,11 +1,6 @@
 const { printDebugInfo } = require('../../../utils/get-debug-info');
 const { getMatchingAdapter } = require('../../../http-clients');
 
-/**
- * this matcher expects axios response to have 5xx status.
- * @param {import('axios').AxiosResponse} expected
- * @returns {{pass: boolean, message: (function(): string)}}
- */
 function toHave5xxStatus(expected) {
   const { matcherHint, printReceived } = this.utils;
 

--- a/src/matchers/status/specific/index.js
+++ b/src/matchers/status/specific/index.js
@@ -1,0 +1,113 @@
+const { toHaveSwitchingProtocolsStatus } = require('./toHaveSwitchingProtocolsStatus.js');
+const { toHaveOkStatus } = require('./toHaveOkStatus.js');
+const { toHaveCreatedStatus } = require('./toHaveCreatedStatus.js');
+const { toHaveAcceptedStatus } = require('./toHaveAcceptedStatus.js');
+const { toHaveNonAuthoritativeInformationStatus } = require('./toHaveNonAuthoritativeInformationStatus.js');
+const { toHaveNoContentStatus } = require('./toHaveNoContentStatus.js');
+const { toHaveResetContentStatus } = require('./toHaveResetContentStatus.js');
+const { toHavePartialContentStatus } = require('./toHavePartialContentStatus.js');
+const { toHaveMultiStatusStatus } = require('./toHaveMultiStatusStatus.js');
+const { toHaveMultipleChoicesStatus } = require('./toHaveMultipleChoicesStatus.js');
+const { toHaveMovedPermanentlyStatus } = require('./toHaveMovedPermanentlyStatus.js');
+const { toHaveMovedTemporarilyStatus } = require('./toHaveMovedTemporarilyStatus.js');
+const { toHaveSeeOtherStatus } = require('./toHaveSeeOtherStatus.js');
+const { toHaveNotModifiedStatus } = require('./toHaveNotModifiedStatus.js');
+const { toHaveUseProxyStatus } = require('./toHaveUseProxyStatus.js');
+const { toHaveTemporaryRedirectStatus } = require('./toHaveTemporaryRedirectStatus.js');
+const { toHavePermanentRedirectStatus } = require('./toHavePermanentRedirectStatus.js');
+const { toHaveBadRequestStatus } = require('./toHaveBadRequestStatus.js');
+const { toHaveUnauthorizedStatus } = require('./toHaveUnauthorizedStatus.js');
+const { toHavePaymentRequiredStatus } = require('./toHavePaymentRequiredStatus.js');
+const { toHaveForbiddenStatus } = require('./toHaveForbiddenStatus.js');
+const { toHaveNotFoundStatus } = require('./toHaveNotFoundStatus.js');
+const { toHaveMethodNotAllowedStatus } = require('./toHaveMethodNotAllowedStatus.js');
+const { toHaveNotAcceptableStatus } = require('./toHaveNotAcceptableStatus.js');
+const { toHaveProxyAuthenticationRequiredStatus } = require('./toHaveProxyAuthenticationRequiredStatus.js');
+const { toHaveRequestTimeoutStatus } = require('./toHaveRequestTimeoutStatus.js');
+const { toHaveConflictStatus } = require('./toHaveConflictStatus.js');
+const { toHaveGoneStatus } = require('./toHaveGoneStatus.js');
+const { toHaveLengthRequiredStatus } = require('./toHaveLengthRequiredStatus.js');
+const { toHavePreconditionFailedStatus } = require('./toHavePreconditionFailedStatus.js');
+const { toHaveRequestTooLongStatus } = require('./toHaveRequestTooLongStatus.js');
+const { toHaveRequestUriTooLongStatus } = require('./toHaveRequestUriTooLongStatus.js');
+const { toHaveUnsupportedMediaTypeStatus } = require('./toHaveUnsupportedMediaTypeStatus.js');
+const { toHaveRequestedRangeNotSatisfiableStatus } = require('./toHaveRequestedRangeNotSatisfiableStatus.js');
+const { toHaveExpectationFailedStatus } = require('./toHaveExpectationFailedStatus.js');
+const { toHaveImATeapotStatus } = require('./toHaveImATeapotStatus.js');
+const { toHaveInsufficientSpaceOnResourceStatus } = require('./toHaveInsufficientSpaceOnResourceStatus.js');
+const { toHaveMethodFailureStatus } = require('./toHaveMethodFailureStatus.js');
+const { toHaveMisdirectedRequestStatus } = require('./toHaveMisdirectedRequestStatus.js');
+const { toHaveUnprocessableEntityStatus } = require('./toHaveUnprocessableEntityStatus.js');
+const { toHaveLockedStatus } = require('./toHaveLockedStatus.js');
+const { toHaveFailedDependencyStatus } = require('./toHaveFailedDependencyStatus.js');
+const { toHaveUpgradeRequiredStatus } = require('./toHaveUpgradeRequiredStatus.js');
+const { toHavePreconditionRequiredStatus } = require('./toHavePreconditionRequiredStatus.js');
+const { toHaveTooManyRequestsStatus } = require('./toHaveTooManyRequestsStatus.js');
+const { toHaveRequestHeaderFieldsTooLargeStatus } = require('./toHaveRequestHeaderFieldsTooLargeStatus.js');
+const { toHaveUnavailableForLegalReasonsStatus } = require('./toHaveUnavailableForLegalReasonsStatus.js');
+const { toHaveInternalServerErrorStatus } = require('./toHaveInternalServerErrorStatus.js');
+const { toHaveNotImplementedStatus } = require('./toHaveNotImplementedStatus.js');
+const { toHaveBadGatewayStatus } = require('./toHaveBadGatewayStatus.js');
+const { toHaveServiceUnavailableStatus } = require('./toHaveServiceUnavailableStatus.js');
+const { toHaveGatewayTimeoutStatus } = require('./toHaveGatewayTimeoutStatus.js');
+const { toHaveHttpVersionNotSupportedStatus } = require('./toHaveHttpVersionNotSupportedStatus.js');
+const { toHaveInsufficientStorageStatus } = require('./toHaveInsufficientStorageStatus.js');
+const { toHaveNetworkAuthenticationRequiredStatus } = require('./toHaveNetworkAuthenticationRequiredStatus.js');
+
+module.exports = {
+  toHaveSwitchingProtocolsStatus,
+  toHaveOkStatus,
+  toHaveCreatedStatus,
+  toHaveAcceptedStatus,
+  toHaveNonAuthoritativeInformationStatus,
+  toHaveNoContentStatus,
+  toHaveResetContentStatus,
+  toHavePartialContentStatus,
+  toHaveMultiStatusStatus,
+  toHaveMultipleChoicesStatus,
+  toHaveMovedPermanentlyStatus,
+  toHaveMovedTemporarilyStatus,
+  toHaveSeeOtherStatus,
+  toHaveNotModifiedStatus,
+  toHaveUseProxyStatus,
+  toHaveTemporaryRedirectStatus,
+  toHavePermanentRedirectStatus,
+  toHaveBadRequestStatus,
+  toHaveUnauthorizedStatus,
+  toHavePaymentRequiredStatus,
+  toHaveForbiddenStatus,
+  toHaveNotFoundStatus,
+  toHaveMethodNotAllowedStatus,
+  toHaveNotAcceptableStatus,
+  toHaveProxyAuthenticationRequiredStatus,
+  toHaveRequestTimeoutStatus,
+  toHaveConflictStatus,
+  toHaveGoneStatus,
+  toHaveLengthRequiredStatus,
+  toHavePreconditionFailedStatus,
+  toHaveRequestTooLongStatus,
+  toHaveRequestUriTooLongStatus,
+  toHaveUnsupportedMediaTypeStatus,
+  toHaveRequestedRangeNotSatisfiableStatus,
+  toHaveExpectationFailedStatus,
+  toHaveImATeapotStatus,
+  toHaveInsufficientSpaceOnResourceStatus,
+  toHaveMethodFailureStatus,
+  toHaveMisdirectedRequestStatus,
+  toHaveUnprocessableEntityStatus,
+  toHaveLockedStatus,
+  toHaveFailedDependencyStatus,
+  toHaveUpgradeRequiredStatus,
+  toHavePreconditionRequiredStatus,
+  toHaveTooManyRequestsStatus,
+  toHaveRequestHeaderFieldsTooLargeStatus,
+  toHaveUnavailableForLegalReasonsStatus,
+  toHaveInternalServerErrorStatus,
+  toHaveNotImplementedStatus,
+  toHaveBadGatewayStatus,
+  toHaveServiceUnavailableStatus,
+  toHaveGatewayTimeoutStatus,
+  toHaveHttpVersionNotSupportedStatus,
+  toHaveInsufficientStorageStatus,
+  toHaveNetworkAuthenticationRequiredStatus,
+};

--- a/src/matchers/status/specific/toHaveAcceptedStatus.js
+++ b/src/matchers/status/specific/toHaveAcceptedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveAcceptedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 202;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveAcceptedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 202 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveAcceptedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 202 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveAcceptedStatus };

--- a/src/matchers/status/specific/toHaveBadGatewayStatus.js
+++ b/src/matchers/status/specific/toHaveBadGatewayStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveBadGatewayStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 502;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveBadGatewayStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 502 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveBadGatewayStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 502 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveBadGatewayStatus };

--- a/src/matchers/status/specific/toHaveBadRequestStatus.js
+++ b/src/matchers/status/specific/toHaveBadRequestStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveBadRequestStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 400;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveBadRequestStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 400 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveBadRequestStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 400 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveBadRequestStatus };

--- a/src/matchers/status/specific/toHaveConflictStatus.js
+++ b/src/matchers/status/specific/toHaveConflictStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveConflictStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 409;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveConflictStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 409 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveConflictStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 409 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveConflictStatus };

--- a/src/matchers/status/specific/toHaveCreatedStatus.js
+++ b/src/matchers/status/specific/toHaveCreatedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveCreatedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 201;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveCreatedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 201 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveCreatedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 201 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveCreatedStatus };

--- a/src/matchers/status/specific/toHaveExpectationFailedStatus.js
+++ b/src/matchers/status/specific/toHaveExpectationFailedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveExpectationFailedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 417;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveExpectationFailedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 417 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveExpectationFailedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 417 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveExpectationFailedStatus };

--- a/src/matchers/status/specific/toHaveFailedDependencyStatus.js
+++ b/src/matchers/status/specific/toHaveFailedDependencyStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveFailedDependencyStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 424;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveFailedDependencyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 424 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveFailedDependencyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 424 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveFailedDependencyStatus };

--- a/src/matchers/status/specific/toHaveForbiddenStatus.js
+++ b/src/matchers/status/specific/toHaveForbiddenStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveForbiddenStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 403;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveForbiddenStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 403 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveForbiddenStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 403 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveForbiddenStatus };

--- a/src/matchers/status/specific/toHaveGatewayTimeoutStatus.js
+++ b/src/matchers/status/specific/toHaveGatewayTimeoutStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveGatewayTimeoutStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 504;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveGatewayTimeoutStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 504 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveGatewayTimeoutStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 504 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveGatewayTimeoutStatus };

--- a/src/matchers/status/specific/toHaveGoneStatus.js
+++ b/src/matchers/status/specific/toHaveGoneStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveGoneStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 410;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveGoneStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 410 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveGoneStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 410 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveGoneStatus };

--- a/src/matchers/status/specific/toHaveHttpVersionNotSupportedStatus.js
+++ b/src/matchers/status/specific/toHaveHttpVersionNotSupportedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveHttpVersionNotSupportedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 505;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveHttpVersionNotSupportedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 505 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveHttpVersionNotSupportedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 505 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveHttpVersionNotSupportedStatus };

--- a/src/matchers/status/specific/toHaveImATeapotStatus.js
+++ b/src/matchers/status/specific/toHaveImATeapotStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveImATeapotStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 418;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveImATeapotStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 418 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveImATeapotStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 418 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveImATeapotStatus };

--- a/src/matchers/status/specific/toHaveInsufficientSpaceOnResourceStatus.js
+++ b/src/matchers/status/specific/toHaveInsufficientSpaceOnResourceStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveInsufficientSpaceOnResourceStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 419;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveInsufficientSpaceOnResourceStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 419 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveInsufficientSpaceOnResourceStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 419 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveInsufficientSpaceOnResourceStatus };

--- a/src/matchers/status/specific/toHaveInsufficientStorageStatus.js
+++ b/src/matchers/status/specific/toHaveInsufficientStorageStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveInsufficientStorageStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 507;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveInsufficientStorageStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 507 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveInsufficientStorageStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 507 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveInsufficientStorageStatus };

--- a/src/matchers/status/specific/toHaveInternalServerErrorStatus.js
+++ b/src/matchers/status/specific/toHaveInternalServerErrorStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveInternalServerErrorStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 500;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveInternalServerErrorStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 500 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveInternalServerErrorStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 500 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveInternalServerErrorStatus };

--- a/src/matchers/status/specific/toHaveLengthRequiredStatus.js
+++ b/src/matchers/status/specific/toHaveLengthRequiredStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveLengthRequiredStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 411;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveLengthRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 411 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveLengthRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 411 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveLengthRequiredStatus };

--- a/src/matchers/status/specific/toHaveLockedStatus.js
+++ b/src/matchers/status/specific/toHaveLockedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveLockedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 423;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveLockedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 423 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveLockedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 423 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveLockedStatus };

--- a/src/matchers/status/specific/toHaveMethodFailureStatus.js
+++ b/src/matchers/status/specific/toHaveMethodFailureStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveMethodFailureStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 420;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveMethodFailureStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 420 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveMethodFailureStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 420 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveMethodFailureStatus };

--- a/src/matchers/status/specific/toHaveMethodNotAllowedStatus.js
+++ b/src/matchers/status/specific/toHaveMethodNotAllowedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveMethodNotAllowedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 405;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveMethodNotAllowedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 405 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveMethodNotAllowedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 405 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveMethodNotAllowedStatus };

--- a/src/matchers/status/specific/toHaveMisdirectedRequestStatus.js
+++ b/src/matchers/status/specific/toHaveMisdirectedRequestStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveMisdirectedRequestStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 421;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveMisdirectedRequestStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 421 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveMisdirectedRequestStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 421 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveMisdirectedRequestStatus };

--- a/src/matchers/status/specific/toHaveMovedPermanentlyStatus.js
+++ b/src/matchers/status/specific/toHaveMovedPermanentlyStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveMovedPermanentlyStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 301;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveMovedPermanentlyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 301 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveMovedPermanentlyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 301 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveMovedPermanentlyStatus };

--- a/src/matchers/status/specific/toHaveMovedTemporarilyStatus.js
+++ b/src/matchers/status/specific/toHaveMovedTemporarilyStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveMovedTemporarilyStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 302;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveMovedTemporarilyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 302 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveMovedTemporarilyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 302 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveMovedTemporarilyStatus };

--- a/src/matchers/status/specific/toHaveMultiStatusStatus.js
+++ b/src/matchers/status/specific/toHaveMultiStatusStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveMultiStatusStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 207;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveMultiStatusStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 207 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveMultiStatusStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 207 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveMultiStatusStatus };

--- a/src/matchers/status/specific/toHaveMultipleChoicesStatus.js
+++ b/src/matchers/status/specific/toHaveMultipleChoicesStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveMultipleChoicesStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 300;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveMultipleChoicesStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 300 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveMultipleChoicesStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 300 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveMultipleChoicesStatus };

--- a/src/matchers/status/specific/toHaveNetworkAuthenticationRequiredStatus.js
+++ b/src/matchers/status/specific/toHaveNetworkAuthenticationRequiredStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveNetworkAuthenticationRequiredStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 511;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveNetworkAuthenticationRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 511 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveNetworkAuthenticationRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 511 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveNetworkAuthenticationRequiredStatus };

--- a/src/matchers/status/specific/toHaveNoContentStatus.js
+++ b/src/matchers/status/specific/toHaveNoContentStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveNoContentStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 204;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveNoContentStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 204 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveNoContentStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 204 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveNoContentStatus };

--- a/src/matchers/status/specific/toHaveNonAuthoritativeInformationStatus.js
+++ b/src/matchers/status/specific/toHaveNonAuthoritativeInformationStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveNonAuthoritativeInformationStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 203;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveNonAuthoritativeInformationStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 203 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveNonAuthoritativeInformationStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 203 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveNonAuthoritativeInformationStatus };

--- a/src/matchers/status/specific/toHaveNotAcceptableStatus.js
+++ b/src/matchers/status/specific/toHaveNotAcceptableStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveNotAcceptableStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 406;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveNotAcceptableStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 406 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveNotAcceptableStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 406 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveNotAcceptableStatus };

--- a/src/matchers/status/specific/toHaveNotFoundStatus.js
+++ b/src/matchers/status/specific/toHaveNotFoundStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveNotFoundStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 404;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveNotFoundStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 404 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveNotFoundStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 404 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveNotFoundStatus };

--- a/src/matchers/status/specific/toHaveNotImplementedStatus.js
+++ b/src/matchers/status/specific/toHaveNotImplementedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveNotImplementedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 501;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveNotImplementedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 501 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveNotImplementedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 501 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveNotImplementedStatus };

--- a/src/matchers/status/specific/toHaveNotModifiedStatus.js
+++ b/src/matchers/status/specific/toHaveNotModifiedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveNotModifiedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 304;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveNotModifiedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 304 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveNotModifiedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 304 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveNotModifiedStatus };

--- a/src/matchers/status/specific/toHaveOkStatus.js
+++ b/src/matchers/status/specific/toHaveOkStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveOkStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 200;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveOkStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 200 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveOkStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 200 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveOkStatus };

--- a/src/matchers/status/specific/toHavePartialContentStatus.js
+++ b/src/matchers/status/specific/toHavePartialContentStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHavePartialContentStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 206;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHavePartialContentStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 206 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHavePartialContentStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 206 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHavePartialContentStatus };

--- a/src/matchers/status/specific/toHavePaymentRequiredStatus.js
+++ b/src/matchers/status/specific/toHavePaymentRequiredStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHavePaymentRequiredStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 402;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHavePaymentRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 402 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHavePaymentRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 402 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHavePaymentRequiredStatus };

--- a/src/matchers/status/specific/toHavePermanentRedirectStatus.js
+++ b/src/matchers/status/specific/toHavePermanentRedirectStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHavePermanentRedirectStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 308;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHavePermanentRedirectStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 308 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHavePermanentRedirectStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 308 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHavePermanentRedirectStatus };

--- a/src/matchers/status/specific/toHavePreconditionFailedStatus.js
+++ b/src/matchers/status/specific/toHavePreconditionFailedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHavePreconditionFailedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 412;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHavePreconditionFailedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 412 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHavePreconditionFailedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 412 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHavePreconditionFailedStatus };

--- a/src/matchers/status/specific/toHavePreconditionRequiredStatus.js
+++ b/src/matchers/status/specific/toHavePreconditionRequiredStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHavePreconditionRequiredStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 428;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHavePreconditionRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 428 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHavePreconditionRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 428 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHavePreconditionRequiredStatus };

--- a/src/matchers/status/specific/toHaveProxyAuthenticationRequiredStatus.js
+++ b/src/matchers/status/specific/toHaveProxyAuthenticationRequiredStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveProxyAuthenticationRequiredStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 407;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveProxyAuthenticationRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 407 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveProxyAuthenticationRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 407 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveProxyAuthenticationRequiredStatus };

--- a/src/matchers/status/specific/toHaveRequestHeaderFieldsTooLargeStatus.js
+++ b/src/matchers/status/specific/toHaveRequestHeaderFieldsTooLargeStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveRequestHeaderFieldsTooLargeStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 431;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveRequestHeaderFieldsTooLargeStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 431 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveRequestHeaderFieldsTooLargeStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 431 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveRequestHeaderFieldsTooLargeStatus };

--- a/src/matchers/status/specific/toHaveRequestTimeoutStatus.js
+++ b/src/matchers/status/specific/toHaveRequestTimeoutStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveRequestTimeoutStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 408;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveRequestTimeoutStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 408 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveRequestTimeoutStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 408 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveRequestTimeoutStatus };

--- a/src/matchers/status/specific/toHaveRequestTooLongStatus.js
+++ b/src/matchers/status/specific/toHaveRequestTooLongStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveRequestTooLongStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 413;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveRequestTooLongStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 413 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveRequestTooLongStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 413 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveRequestTooLongStatus };

--- a/src/matchers/status/specific/toHaveRequestUriTooLongStatus.js
+++ b/src/matchers/status/specific/toHaveRequestUriTooLongStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveRequestUriTooLongStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 414;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveRequestUriTooLongStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 414 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveRequestUriTooLongStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 414 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveRequestUriTooLongStatus };

--- a/src/matchers/status/specific/toHaveRequestedRangeNotSatisfiableStatus.js
+++ b/src/matchers/status/specific/toHaveRequestedRangeNotSatisfiableStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveRequestedRangeNotSatisfiableStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 416;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveRequestedRangeNotSatisfiableStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 416 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveRequestedRangeNotSatisfiableStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 416 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveRequestedRangeNotSatisfiableStatus };

--- a/src/matchers/status/specific/toHaveResetContentStatus.js
+++ b/src/matchers/status/specific/toHaveResetContentStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveResetContentStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 205;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveResetContentStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 205 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveResetContentStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 205 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveResetContentStatus };

--- a/src/matchers/status/specific/toHaveSeeOtherStatus.js
+++ b/src/matchers/status/specific/toHaveSeeOtherStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveSeeOtherStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 303;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveSeeOtherStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 303 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveSeeOtherStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 303 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveSeeOtherStatus };

--- a/src/matchers/status/specific/toHaveServiceUnavailableStatus.js
+++ b/src/matchers/status/specific/toHaveServiceUnavailableStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveServiceUnavailableStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 503;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveServiceUnavailableStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 503 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveServiceUnavailableStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 503 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveServiceUnavailableStatus };

--- a/src/matchers/status/specific/toHaveSwitchingProtocolsStatus.js
+++ b/src/matchers/status/specific/toHaveSwitchingProtocolsStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveSwitchingProtocolsStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 101;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveSwitchingProtocolsStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 101 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveSwitchingProtocolsStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 101 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveSwitchingProtocolsStatus };

--- a/src/matchers/status/specific/toHaveTemporaryRedirectStatus.js
+++ b/src/matchers/status/specific/toHaveTemporaryRedirectStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveTemporaryRedirectStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 307;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveTemporaryRedirectStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 307 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveTemporaryRedirectStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 307 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveTemporaryRedirectStatus };

--- a/src/matchers/status/specific/toHaveTooManyRequestsStatus.js
+++ b/src/matchers/status/specific/toHaveTooManyRequestsStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveTooManyRequestsStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 429;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveTooManyRequestsStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 429 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveTooManyRequestsStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 429 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveTooManyRequestsStatus };

--- a/src/matchers/status/specific/toHaveUnauthorizedStatus.js
+++ b/src/matchers/status/specific/toHaveUnauthorizedStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveUnauthorizedStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 401;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveUnauthorizedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 401 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveUnauthorizedStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 401 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveUnauthorizedStatus };

--- a/src/matchers/status/specific/toHaveUnavailableForLegalReasonsStatus.js
+++ b/src/matchers/status/specific/toHaveUnavailableForLegalReasonsStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveUnavailableForLegalReasonsStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 451;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveUnavailableForLegalReasonsStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 451 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveUnavailableForLegalReasonsStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 451 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveUnavailableForLegalReasonsStatus };

--- a/src/matchers/status/specific/toHaveUnprocessableEntityStatus.js
+++ b/src/matchers/status/specific/toHaveUnprocessableEntityStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveUnprocessableEntityStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 422;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveUnprocessableEntityStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 422 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveUnprocessableEntityStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 422 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveUnprocessableEntityStatus };

--- a/src/matchers/status/specific/toHaveUnsupportedMediaTypeStatus.js
+++ b/src/matchers/status/specific/toHaveUnsupportedMediaTypeStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveUnsupportedMediaTypeStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 415;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveUnsupportedMediaTypeStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 415 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveUnsupportedMediaTypeStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 415 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveUnsupportedMediaTypeStatus };

--- a/src/matchers/status/specific/toHaveUpgradeRequiredStatus.js
+++ b/src/matchers/status/specific/toHaveUpgradeRequiredStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveUpgradeRequiredStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 426;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveUpgradeRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 426 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveUpgradeRequiredStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 426 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveUpgradeRequiredStatus };

--- a/src/matchers/status/specific/toHaveUseProxyStatus.js
+++ b/src/matchers/status/specific/toHaveUseProxyStatus.js
@@ -1,0 +1,29 @@
+const { printDebugInfo } = require('../../../utils/get-debug-info');
+const { getMatchingAdapter } = require('../../../http-clients');
+
+function toHaveUseProxyStatus(expected) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const adapter = getMatchingAdapter(expected);
+  const status = adapter.getStatusCode();
+
+  const pass = status === 305;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('not.toHaveUseProxyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to not be 305 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter)
+        : matcherHint('.toHaveUseProxyStatus', 'received', '') +
+          '\n\n' +
+          'Expected status code to be 305 received:\n' +
+          `  ${printReceived(status)}\n\n` +
+          printDebugInfo(adapter),
+  };
+}
+
+module.exports = { toHaveUseProxyStatus };

--- a/test/matchers/status/specific/toHaveAcceptedStatus.test.js
+++ b/test/matchers/status/specific/toHaveAcceptedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveAcceptedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveAcceptedStatus });
+
+describe('(.not).toHaveAcceptedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveAcceptedStatus', () => {
+        test('passes when response has status code ACCEPTED (202)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 202,
+          });
+
+          expect(response).toHaveAcceptedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 202) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveAcceptedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveAcceptedStatus', () => {
+        test('passes when given status code 200 to 599 except 202', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 202) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveAcceptedStatus();
+          }
+        });
+
+        test(`fails when response have status code 202`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 202,
+          });
+
+          try {
+            expect(response).not.toHaveAcceptedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveBadGatewayStatus.test.js
+++ b/test/matchers/status/specific/toHaveBadGatewayStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveBadGatewayStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveBadGatewayStatus });
+
+describe('(.not).toHaveBadGatewayStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveBadGatewayStatus', () => {
+        test('passes when response has status code BAD_GATEWAY (502)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 502,
+          });
+
+          expect(response).toHaveBadGatewayStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 502) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveBadGatewayStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveBadGatewayStatus', () => {
+        test('passes when given status code 200 to 599 except 502', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 502) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveBadGatewayStatus();
+          }
+        });
+
+        test(`fails when response have status code 502`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 502,
+          });
+
+          try {
+            expect(response).not.toHaveBadGatewayStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveBadRequestStatus.test.js
+++ b/test/matchers/status/specific/toHaveBadRequestStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveBadRequestStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveBadRequestStatus });
+
+describe('(.not).toHaveBadRequestStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveBadRequestStatus', () => {
+        test('passes when response has status code BAD_REQUEST (400)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 400,
+          });
+
+          expect(response).toHaveBadRequestStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 400) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveBadRequestStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveBadRequestStatus', () => {
+        test('passes when given status code 200 to 599 except 400', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 400) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveBadRequestStatus();
+          }
+        });
+
+        test(`fails when response have status code 400`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 400,
+          });
+
+          try {
+            expect(response).not.toHaveBadRequestStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveConflictStatus.test.js
+++ b/test/matchers/status/specific/toHaveConflictStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveConflictStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveConflictStatus });
+
+describe('(.not).toHaveConflictStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveConflictStatus', () => {
+        test('passes when response has status code CONFLICT (409)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 409,
+          });
+
+          expect(response).toHaveConflictStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 409) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveConflictStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveConflictStatus', () => {
+        test('passes when given status code 200 to 599 except 409', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 409) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveConflictStatus();
+          }
+        });
+
+        test(`fails when response have status code 409`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 409,
+          });
+
+          try {
+            expect(response).not.toHaveConflictStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveCreatedStatus.test.js
+++ b/test/matchers/status/specific/toHaveCreatedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveCreatedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveCreatedStatus });
+
+describe('(.not).toHaveCreatedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveCreatedStatus', () => {
+        test('passes when response has status code CREATED (201)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 201,
+          });
+
+          expect(response).toHaveCreatedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 201) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveCreatedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveCreatedStatus', () => {
+        test('passes when given status code 200 to 599 except 201', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 201) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveCreatedStatus();
+          }
+        });
+
+        test(`fails when response have status code 201`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 201,
+          });
+
+          try {
+            expect(response).not.toHaveCreatedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveExpectationFailedStatus.test.js
+++ b/test/matchers/status/specific/toHaveExpectationFailedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveExpectationFailedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveExpectationFailedStatus });
+
+describe('(.not).toHaveExpectationFailedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveExpectationFailedStatus', () => {
+        test('passes when response has status code EXPECTATION_FAILED (417)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 417,
+          });
+
+          expect(response).toHaveExpectationFailedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 417) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveExpectationFailedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveExpectationFailedStatus', () => {
+        test('passes when given status code 200 to 599 except 417', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 417) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveExpectationFailedStatus();
+          }
+        });
+
+        test(`fails when response have status code 417`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 417,
+          });
+
+          try {
+            expect(response).not.toHaveExpectationFailedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveFailedDependencyStatus.test.js
+++ b/test/matchers/status/specific/toHaveFailedDependencyStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveFailedDependencyStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveFailedDependencyStatus });
+
+describe('(.not).toHaveFailedDependencyStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveFailedDependencyStatus', () => {
+        test('passes when response has status code FAILED_DEPENDENCY (424)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 424,
+          });
+
+          expect(response).toHaveFailedDependencyStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 424) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveFailedDependencyStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveFailedDependencyStatus', () => {
+        test('passes when given status code 200 to 599 except 424', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 424) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveFailedDependencyStatus();
+          }
+        });
+
+        test(`fails when response have status code 424`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 424,
+          });
+
+          try {
+            expect(response).not.toHaveFailedDependencyStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveForbiddenStatus.test.js
+++ b/test/matchers/status/specific/toHaveForbiddenStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveForbiddenStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveForbiddenStatus });
+
+describe('(.not).toHaveForbiddenStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveForbiddenStatus', () => {
+        test('passes when response has status code FORBIDDEN (403)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 403,
+          });
+
+          expect(response).toHaveForbiddenStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 403) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveForbiddenStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveForbiddenStatus', () => {
+        test('passes when given status code 200 to 599 except 403', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 403) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveForbiddenStatus();
+          }
+        });
+
+        test(`fails when response have status code 403`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 403,
+          });
+
+          try {
+            expect(response).not.toHaveForbiddenStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveGatewayTimeoutStatus.test.js
+++ b/test/matchers/status/specific/toHaveGatewayTimeoutStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveGatewayTimeoutStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveGatewayTimeoutStatus });
+
+describe('(.not).toHaveGatewayTimeoutStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveGatewayTimeoutStatus', () => {
+        test('passes when response has status code GATEWAY_TIMEOUT (504)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 504,
+          });
+
+          expect(response).toHaveGatewayTimeoutStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 504) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveGatewayTimeoutStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveGatewayTimeoutStatus', () => {
+        test('passes when given status code 200 to 599 except 504', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 504) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveGatewayTimeoutStatus();
+          }
+        });
+
+        test(`fails when response have status code 504`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 504,
+          });
+
+          try {
+            expect(response).not.toHaveGatewayTimeoutStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveGoneStatus.test.js
+++ b/test/matchers/status/specific/toHaveGoneStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveGoneStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveGoneStatus });
+
+describe('(.not).toHaveGoneStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveGoneStatus', () => {
+        test('passes when response has status code GONE (410)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 410,
+          });
+
+          expect(response).toHaveGoneStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 410) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveGoneStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveGoneStatus', () => {
+        test('passes when given status code 200 to 599 except 410', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 410) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveGoneStatus();
+          }
+        });
+
+        test(`fails when response have status code 410`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 410,
+          });
+
+          try {
+            expect(response).not.toHaveGoneStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveHttpVersionNotSupportedStatus.test.js
+++ b/test/matchers/status/specific/toHaveHttpVersionNotSupportedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveHttpVersionNotSupportedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveHttpVersionNotSupportedStatus });
+
+describe('(.not).toHaveHttpVersionNotSupportedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveHttpVersionNotSupportedStatus', () => {
+        test('passes when response has status code HTTP_VERSION_NOT_SUPPORTED (505)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 505,
+          });
+
+          expect(response).toHaveHttpVersionNotSupportedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 505) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveHttpVersionNotSupportedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveHttpVersionNotSupportedStatus', () => {
+        test('passes when given status code 200 to 599 except 505', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 505) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveHttpVersionNotSupportedStatus();
+          }
+        });
+
+        test(`fails when response have status code 505`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 505,
+          });
+
+          try {
+            expect(response).not.toHaveHttpVersionNotSupportedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveImATeapotStatus.test.js
+++ b/test/matchers/status/specific/toHaveImATeapotStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveImATeapotStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveImATeapotStatus });
+
+describe('(.not).toHaveImATeapotStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveImATeapotStatus', () => {
+        test('passes when response has status code IM_A_TEAPOT (418)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 418,
+          });
+
+          expect(response).toHaveImATeapotStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 418) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveImATeapotStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveImATeapotStatus', () => {
+        test('passes when given status code 200 to 599 except 418', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 418) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveImATeapotStatus();
+          }
+        });
+
+        test(`fails when response have status code 418`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 418,
+          });
+
+          try {
+            expect(response).not.toHaveImATeapotStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveInsufficientSpaceOnResourceStatus.test.js
+++ b/test/matchers/status/specific/toHaveInsufficientSpaceOnResourceStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveInsufficientSpaceOnResourceStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveInsufficientSpaceOnResourceStatus });
+
+describe('(.not).toHaveInsufficientSpaceOnResourceStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveInsufficientSpaceOnResourceStatus', () => {
+        test('passes when response has status code INSUFFICIENT_SPACE_ON_RESOURCE (419)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 419,
+          });
+
+          expect(response).toHaveInsufficientSpaceOnResourceStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 419) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveInsufficientSpaceOnResourceStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveInsufficientSpaceOnResourceStatus', () => {
+        test('passes when given status code 200 to 599 except 419', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 419) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveInsufficientSpaceOnResourceStatus();
+          }
+        });
+
+        test(`fails when response have status code 419`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 419,
+          });
+
+          try {
+            expect(response).not.toHaveInsufficientSpaceOnResourceStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveInsufficientStorageStatus.test.js
+++ b/test/matchers/status/specific/toHaveInsufficientStorageStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveInsufficientStorageStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveInsufficientStorageStatus });
+
+describe('(.not).toHaveInsufficientStorageStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveInsufficientStorageStatus', () => {
+        test('passes when response has status code INSUFFICIENT_STORAGE (507)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 507,
+          });
+
+          expect(response).toHaveInsufficientStorageStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 507) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveInsufficientStorageStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveInsufficientStorageStatus', () => {
+        test('passes when given status code 200 to 599 except 507', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 507) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveInsufficientStorageStatus();
+          }
+        });
+
+        test(`fails when response have status code 507`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 507,
+          });
+
+          try {
+            expect(response).not.toHaveInsufficientStorageStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveInternalServerErrorStatus.test.js
+++ b/test/matchers/status/specific/toHaveInternalServerErrorStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveInternalServerErrorStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveInternalServerErrorStatus });
+
+describe('(.not).toHaveInternalServerErrorStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveInternalServerErrorStatus', () => {
+        test('passes when response has status code INTERNAL_SERVER_ERROR (500)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 500,
+          });
+
+          expect(response).toHaveInternalServerErrorStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 500) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveInternalServerErrorStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveInternalServerErrorStatus', () => {
+        test('passes when given status code 200 to 599 except 500', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 500) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveInternalServerErrorStatus();
+          }
+        });
+
+        test(`fails when response have status code 500`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 500,
+          });
+
+          try {
+            expect(response).not.toHaveInternalServerErrorStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveLengthRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveLengthRequiredStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveLengthRequiredStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveLengthRequiredStatus });
+
+describe('(.not).toHaveLengthRequiredStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveLengthRequiredStatus', () => {
+        test('passes when response has status code LENGTH_REQUIRED (411)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 411,
+          });
+
+          expect(response).toHaveLengthRequiredStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 411) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveLengthRequiredStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveLengthRequiredStatus', () => {
+        test('passes when given status code 200 to 599 except 411', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 411) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveLengthRequiredStatus();
+          }
+        });
+
+        test(`fails when response have status code 411`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 411,
+          });
+
+          try {
+            expect(response).not.toHaveLengthRequiredStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveLockedStatus.test.js
+++ b/test/matchers/status/specific/toHaveLockedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveLockedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveLockedStatus });
+
+describe('(.not).toHaveLockedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveLockedStatus', () => {
+        test('passes when response has status code LOCKED (423)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 423,
+          });
+
+          expect(response).toHaveLockedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 423) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveLockedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveLockedStatus', () => {
+        test('passes when given status code 200 to 599 except 423', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 423) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveLockedStatus();
+          }
+        });
+
+        test(`fails when response have status code 423`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 423,
+          });
+
+          try {
+            expect(response).not.toHaveLockedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveMethodFailureStatus.test.js
+++ b/test/matchers/status/specific/toHaveMethodFailureStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveMethodFailureStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveMethodFailureStatus });
+
+describe('(.not).toHaveMethodFailureStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveMethodFailureStatus', () => {
+        test('passes when response has status code METHOD_FAILURE (420)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 420,
+          });
+
+          expect(response).toHaveMethodFailureStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 420) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveMethodFailureStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveMethodFailureStatus', () => {
+        test('passes when given status code 200 to 599 except 420', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 420) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveMethodFailureStatus();
+          }
+        });
+
+        test(`fails when response have status code 420`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 420,
+          });
+
+          try {
+            expect(response).not.toHaveMethodFailureStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveMethodNotAllowedStatus.test.js
+++ b/test/matchers/status/specific/toHaveMethodNotAllowedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveMethodNotAllowedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveMethodNotAllowedStatus });
+
+describe('(.not).toHaveMethodNotAllowedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveMethodNotAllowedStatus', () => {
+        test('passes when response has status code METHOD_NOT_ALLOWED (405)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 405,
+          });
+
+          expect(response).toHaveMethodNotAllowedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 405) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveMethodNotAllowedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveMethodNotAllowedStatus', () => {
+        test('passes when given status code 200 to 599 except 405', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 405) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveMethodNotAllowedStatus();
+          }
+        });
+
+        test(`fails when response have status code 405`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 405,
+          });
+
+          try {
+            expect(response).not.toHaveMethodNotAllowedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveMisdirectedRequestStatus.test.js
+++ b/test/matchers/status/specific/toHaveMisdirectedRequestStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveMisdirectedRequestStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveMisdirectedRequestStatus });
+
+describe('(.not).toHaveMisdirectedRequestStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveMisdirectedRequestStatus', () => {
+        test('passes when response has status code MISDIRECTED_REQUEST (421)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 421,
+          });
+
+          expect(response).toHaveMisdirectedRequestStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 421) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveMisdirectedRequestStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveMisdirectedRequestStatus', () => {
+        test('passes when given status code 200 to 599 except 421', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 421) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveMisdirectedRequestStatus();
+          }
+        });
+
+        test(`fails when response have status code 421`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 421,
+          });
+
+          try {
+            expect(response).not.toHaveMisdirectedRequestStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveMovedPermanentlyStatus.test.js
+++ b/test/matchers/status/specific/toHaveMovedPermanentlyStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveMovedPermanentlyStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveMovedPermanentlyStatus });
+
+describe('(.not).toHaveMovedPermanentlyStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveMovedPermanentlyStatus', () => {
+        test('passes when response has status code MOVED_PERMANENTLY (301)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 301,
+          });
+
+          expect(response).toHaveMovedPermanentlyStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 301) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveMovedPermanentlyStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveMovedPermanentlyStatus', () => {
+        test('passes when given status code 200 to 599 except 301', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 301) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveMovedPermanentlyStatus();
+          }
+        });
+
+        test(`fails when response have status code 301`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 301,
+          });
+
+          try {
+            expect(response).not.toHaveMovedPermanentlyStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveMovedTemporarilyStatus.test.js
+++ b/test/matchers/status/specific/toHaveMovedTemporarilyStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveMovedTemporarilyStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveMovedTemporarilyStatus });
+
+describe('(.not).toHaveMovedTemporarilyStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveMovedTemporarilyStatus', () => {
+        test('passes when response has status code MOVED_TEMPORARILY (302)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 302,
+          });
+
+          expect(response).toHaveMovedTemporarilyStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 302) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveMovedTemporarilyStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveMovedTemporarilyStatus', () => {
+        test('passes when given status code 200 to 599 except 302', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 302) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveMovedTemporarilyStatus();
+          }
+        });
+
+        test(`fails when response have status code 302`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 302,
+          });
+
+          try {
+            expect(response).not.toHaveMovedTemporarilyStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveMultiStatusStatus.test.js
+++ b/test/matchers/status/specific/toHaveMultiStatusStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveMultiStatusStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveMultiStatusStatus });
+
+describe('(.not).toHaveMultiStatusStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveMultiStatusStatus', () => {
+        test('passes when response has status code MULTI_STATUS (207)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 207,
+          });
+
+          expect(response).toHaveMultiStatusStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 207) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveMultiStatusStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveMultiStatusStatus', () => {
+        test('passes when given status code 200 to 599 except 207', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 207) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveMultiStatusStatus();
+          }
+        });
+
+        test(`fails when response have status code 207`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 207,
+          });
+
+          try {
+            expect(response).not.toHaveMultiStatusStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveMultipleChoicesStatus.test.js
+++ b/test/matchers/status/specific/toHaveMultipleChoicesStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveMultipleChoicesStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveMultipleChoicesStatus });
+
+describe('(.not).toHaveMultipleChoicesStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveMultipleChoicesStatus', () => {
+        test('passes when response has status code MULTIPLE_CHOICES (300)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 300,
+          });
+
+          expect(response).toHaveMultipleChoicesStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 300) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveMultipleChoicesStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveMultipleChoicesStatus', () => {
+        test('passes when given status code 200 to 599 except 300', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 300) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveMultipleChoicesStatus();
+          }
+        });
+
+        test(`fails when response have status code 300`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 300,
+          });
+
+          try {
+            expect(response).not.toHaveMultipleChoicesStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveNetworkAuthenticationRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveNetworkAuthenticationRequiredStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveNetworkAuthenticationRequiredStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveNetworkAuthenticationRequiredStatus });
+
+describe('(.not).toHaveNetworkAuthenticationRequiredStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveNetworkAuthenticationRequiredStatus', () => {
+        test('passes when response has status code NETWORK_AUTHENTICATION_REQUIRED (511)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 511,
+          });
+
+          expect(response).toHaveNetworkAuthenticationRequiredStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 511) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveNetworkAuthenticationRequiredStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveNetworkAuthenticationRequiredStatus', () => {
+        test('passes when given status code 200 to 599 except 511', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 511) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveNetworkAuthenticationRequiredStatus();
+          }
+        });
+
+        test(`fails when response have status code 511`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 511,
+          });
+
+          try {
+            expect(response).not.toHaveNetworkAuthenticationRequiredStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveNoContentStatus.test.js
+++ b/test/matchers/status/specific/toHaveNoContentStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveNoContentStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveNoContentStatus });
+
+describe('(.not).toHaveNoContentStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveNoContentStatus', () => {
+        test('passes when response has status code NO_CONTENT (204)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 204,
+          });
+
+          expect(response).toHaveNoContentStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 204) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveNoContentStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveNoContentStatus', () => {
+        test('passes when given status code 200 to 599 except 204', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 204) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveNoContentStatus();
+          }
+        });
+
+        test(`fails when response have status code 204`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 204,
+          });
+
+          try {
+            expect(response).not.toHaveNoContentStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveNonAuthoritativeInformationStatus.test.js
+++ b/test/matchers/status/specific/toHaveNonAuthoritativeInformationStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveNonAuthoritativeInformationStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveNonAuthoritativeInformationStatus });
+
+describe('(.not).toHaveNonAuthoritativeInformationStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveNonAuthoritativeInformationStatus', () => {
+        test('passes when response has status code NON_AUTHORITATIVE_INFORMATION (203)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 203,
+          });
+
+          expect(response).toHaveNonAuthoritativeInformationStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 203) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveNonAuthoritativeInformationStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveNonAuthoritativeInformationStatus', () => {
+        test('passes when given status code 200 to 599 except 203', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 203) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveNonAuthoritativeInformationStatus();
+          }
+        });
+
+        test(`fails when response have status code 203`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 203,
+          });
+
+          try {
+            expect(response).not.toHaveNonAuthoritativeInformationStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveNotAcceptableStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotAcceptableStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveNotAcceptableStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveNotAcceptableStatus });
+
+describe('(.not).toHaveNotAcceptableStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveNotAcceptableStatus', () => {
+        test('passes when response has status code NOT_ACCEPTABLE (406)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 406,
+          });
+
+          expect(response).toHaveNotAcceptableStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 406) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveNotAcceptableStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveNotAcceptableStatus', () => {
+        test('passes when given status code 200 to 599 except 406', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 406) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveNotAcceptableStatus();
+          }
+        });
+
+        test(`fails when response have status code 406`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 406,
+          });
+
+          try {
+            expect(response).not.toHaveNotAcceptableStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveNotFoundStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotFoundStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveNotFoundStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveNotFoundStatus });
+
+describe('(.not).toHaveNotFoundStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveNotFoundStatus', () => {
+        test('passes when response has status code NOT_FOUND (404)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 404,
+          });
+
+          expect(response).toHaveNotFoundStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 404) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveNotFoundStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveNotFoundStatus', () => {
+        test('passes when given status code 200 to 599 except 404', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 404) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveNotFoundStatus();
+          }
+        });
+
+        test(`fails when response have status code 404`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 404,
+          });
+
+          try {
+            expect(response).not.toHaveNotFoundStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveNotImplementedStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotImplementedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveNotImplementedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveNotImplementedStatus });
+
+describe('(.not).toHaveNotImplementedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveNotImplementedStatus', () => {
+        test('passes when response has status code NOT_IMPLEMENTED (501)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 501,
+          });
+
+          expect(response).toHaveNotImplementedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 501) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveNotImplementedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveNotImplementedStatus', () => {
+        test('passes when given status code 200 to 599 except 501', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 501) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveNotImplementedStatus();
+          }
+        });
+
+        test(`fails when response have status code 501`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 501,
+          });
+
+          try {
+            expect(response).not.toHaveNotImplementedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveNotModifiedStatus.test.js
+++ b/test/matchers/status/specific/toHaveNotModifiedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveNotModifiedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveNotModifiedStatus });
+
+describe('(.not).toHaveNotModifiedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveNotModifiedStatus', () => {
+        test('passes when response has status code NOT_MODIFIED (304)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 304,
+          });
+
+          expect(response).toHaveNotModifiedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 304) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveNotModifiedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveNotModifiedStatus', () => {
+        test('passes when given status code 200 to 599 except 304', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 304) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveNotModifiedStatus();
+          }
+        });
+
+        test(`fails when response have status code 304`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 304,
+          });
+
+          try {
+            expect(response).not.toHaveNotModifiedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveOkStatus.test.js
+++ b/test/matchers/status/specific/toHaveOkStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveOkStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveOkStatus });
+
+describe('(.not).toHaveOkStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveOkStatus', () => {
+        test('passes when response has status code OK (200)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 200,
+          });
+
+          expect(response).toHaveOkStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 200) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveOkStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveOkStatus', () => {
+        test('passes when given status code 200 to 599 except 200', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 200) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveOkStatus();
+          }
+        });
+
+        test(`fails when response have status code 200`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 200,
+          });
+
+          try {
+            expect(response).not.toHaveOkStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHavePartialContentStatus.test.js
+++ b/test/matchers/status/specific/toHavePartialContentStatus.test.js
@@ -1,0 +1,89 @@
+const { toHavePartialContentStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHavePartialContentStatus });
+
+describe('(.not).toHavePartialContentStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHavePartialContentStatus', () => {
+        test('passes when response has status code PARTIAL_CONTENT (206)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 206,
+          });
+
+          expect(response).toHavePartialContentStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 206) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHavePartialContentStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHavePartialContentStatus', () => {
+        test('passes when given status code 200 to 599 except 206', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 206) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHavePartialContentStatus();
+          }
+        });
+
+        test(`fails when response have status code 206`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 206,
+          });
+
+          try {
+            expect(response).not.toHavePartialContentStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHavePaymentRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHavePaymentRequiredStatus.test.js
@@ -1,0 +1,89 @@
+const { toHavePaymentRequiredStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHavePaymentRequiredStatus });
+
+describe('(.not).toHavePaymentRequiredStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHavePaymentRequiredStatus', () => {
+        test('passes when response has status code PAYMENT_REQUIRED (402)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 402,
+          });
+
+          expect(response).toHavePaymentRequiredStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 402) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHavePaymentRequiredStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHavePaymentRequiredStatus', () => {
+        test('passes when given status code 200 to 599 except 402', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 402) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHavePaymentRequiredStatus();
+          }
+        });
+
+        test(`fails when response have status code 402`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 402,
+          });
+
+          try {
+            expect(response).not.toHavePaymentRequiredStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHavePermanentRedirectStatus.test.js
+++ b/test/matchers/status/specific/toHavePermanentRedirectStatus.test.js
@@ -1,0 +1,89 @@
+const { toHavePermanentRedirectStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHavePermanentRedirectStatus });
+
+describe('(.not).toHavePermanentRedirectStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHavePermanentRedirectStatus', () => {
+        test('passes when response has status code PERMANENT_REDIRECT (308)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 308,
+          });
+
+          expect(response).toHavePermanentRedirectStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 308) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHavePermanentRedirectStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHavePermanentRedirectStatus', () => {
+        test('passes when given status code 200 to 599 except 308', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 308) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHavePermanentRedirectStatus();
+          }
+        });
+
+        test(`fails when response have status code 308`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 308,
+          });
+
+          try {
+            expect(response).not.toHavePermanentRedirectStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHavePreconditionFailedStatus.test.js
+++ b/test/matchers/status/specific/toHavePreconditionFailedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHavePreconditionFailedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHavePreconditionFailedStatus });
+
+describe('(.not).toHavePreconditionFailedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHavePreconditionFailedStatus', () => {
+        test('passes when response has status code PRECONDITION_FAILED (412)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 412,
+          });
+
+          expect(response).toHavePreconditionFailedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 412) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHavePreconditionFailedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHavePreconditionFailedStatus', () => {
+        test('passes when given status code 200 to 599 except 412', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 412) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHavePreconditionFailedStatus();
+          }
+        });
+
+        test(`fails when response have status code 412`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 412,
+          });
+
+          try {
+            expect(response).not.toHavePreconditionFailedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHavePreconditionRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHavePreconditionRequiredStatus.test.js
@@ -1,0 +1,89 @@
+const { toHavePreconditionRequiredStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHavePreconditionRequiredStatus });
+
+describe('(.not).toHavePreconditionRequiredStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHavePreconditionRequiredStatus', () => {
+        test('passes when response has status code PRECONDITION_REQUIRED (428)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 428,
+          });
+
+          expect(response).toHavePreconditionRequiredStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 428) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHavePreconditionRequiredStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHavePreconditionRequiredStatus', () => {
+        test('passes when given status code 200 to 599 except 428', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 428) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHavePreconditionRequiredStatus();
+          }
+        });
+
+        test(`fails when response have status code 428`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 428,
+          });
+
+          try {
+            expect(response).not.toHavePreconditionRequiredStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveProxyAuthenticationRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveProxyAuthenticationRequiredStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveProxyAuthenticationRequiredStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveProxyAuthenticationRequiredStatus });
+
+describe('(.not).toHaveProxyAuthenticationRequiredStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveProxyAuthenticationRequiredStatus', () => {
+        test('passes when response has status code PROXY_AUTHENTICATION_REQUIRED (407)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 407,
+          });
+
+          expect(response).toHaveProxyAuthenticationRequiredStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 407) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveProxyAuthenticationRequiredStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveProxyAuthenticationRequiredStatus', () => {
+        test('passes when given status code 200 to 599 except 407', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 407) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveProxyAuthenticationRequiredStatus();
+          }
+        });
+
+        test(`fails when response have status code 407`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 407,
+          });
+
+          try {
+            expect(response).not.toHaveProxyAuthenticationRequiredStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveRequestHeaderFieldsTooLargeStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestHeaderFieldsTooLargeStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveRequestHeaderFieldsTooLargeStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveRequestHeaderFieldsTooLargeStatus });
+
+describe('(.not).toHaveRequestHeaderFieldsTooLargeStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveRequestHeaderFieldsTooLargeStatus', () => {
+        test('passes when response has status code REQUEST_HEADER_FIELDS_TOO_LARGE (431)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 431,
+          });
+
+          expect(response).toHaveRequestHeaderFieldsTooLargeStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 431) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveRequestHeaderFieldsTooLargeStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveRequestHeaderFieldsTooLargeStatus', () => {
+        test('passes when given status code 200 to 599 except 431', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 431) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveRequestHeaderFieldsTooLargeStatus();
+          }
+        });
+
+        test(`fails when response have status code 431`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 431,
+          });
+
+          try {
+            expect(response).not.toHaveRequestHeaderFieldsTooLargeStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveRequestTimeoutStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestTimeoutStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveRequestTimeoutStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveRequestTimeoutStatus });
+
+describe('(.not).toHaveRequestTimeoutStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveRequestTimeoutStatus', () => {
+        test('passes when response has status code REQUEST_TIMEOUT (408)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 408,
+          });
+
+          expect(response).toHaveRequestTimeoutStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 408) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveRequestTimeoutStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveRequestTimeoutStatus', () => {
+        test('passes when given status code 200 to 599 except 408', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 408) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveRequestTimeoutStatus();
+          }
+        });
+
+        test(`fails when response have status code 408`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 408,
+          });
+
+          try {
+            expect(response).not.toHaveRequestTimeoutStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveRequestTooLongStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestTooLongStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveRequestTooLongStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveRequestTooLongStatus });
+
+describe('(.not).toHaveRequestTooLongStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveRequestTooLongStatus', () => {
+        test('passes when response has status code REQUEST_TOO_LONG (413)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 413,
+          });
+
+          expect(response).toHaveRequestTooLongStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 413) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveRequestTooLongStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveRequestTooLongStatus', () => {
+        test('passes when given status code 200 to 599 except 413', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 413) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveRequestTooLongStatus();
+          }
+        });
+
+        test(`fails when response have status code 413`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 413,
+          });
+
+          try {
+            expect(response).not.toHaveRequestTooLongStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveRequestUriTooLongStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestUriTooLongStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveRequestUriTooLongStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveRequestUriTooLongStatus });
+
+describe('(.not).toHaveRequestUriTooLongStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveRequestUriTooLongStatus', () => {
+        test('passes when response has status code REQUEST_URI_TOO_LONG (414)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 414,
+          });
+
+          expect(response).toHaveRequestUriTooLongStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 414) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveRequestUriTooLongStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveRequestUriTooLongStatus', () => {
+        test('passes when given status code 200 to 599 except 414', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 414) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveRequestUriTooLongStatus();
+          }
+        });
+
+        test(`fails when response have status code 414`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 414,
+          });
+
+          try {
+            expect(response).not.toHaveRequestUriTooLongStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveRequestedRangeNotSatisfiableStatus.test.js
+++ b/test/matchers/status/specific/toHaveRequestedRangeNotSatisfiableStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveRequestedRangeNotSatisfiableStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveRequestedRangeNotSatisfiableStatus });
+
+describe('(.not).toHaveRequestedRangeNotSatisfiableStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveRequestedRangeNotSatisfiableStatus', () => {
+        test('passes when response has status code REQUESTED_RANGE_NOT_SATISFIABLE (416)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 416,
+          });
+
+          expect(response).toHaveRequestedRangeNotSatisfiableStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 416) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveRequestedRangeNotSatisfiableStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveRequestedRangeNotSatisfiableStatus', () => {
+        test('passes when given status code 200 to 599 except 416', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 416) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveRequestedRangeNotSatisfiableStatus();
+          }
+        });
+
+        test(`fails when response have status code 416`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 416,
+          });
+
+          try {
+            expect(response).not.toHaveRequestedRangeNotSatisfiableStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveResetContentStatus.test.js
+++ b/test/matchers/status/specific/toHaveResetContentStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveResetContentStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveResetContentStatus });
+
+describe('(.not).toHaveResetContentStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveResetContentStatus', () => {
+        test('passes when response has status code RESET_CONTENT (205)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 205,
+          });
+
+          expect(response).toHaveResetContentStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 205) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveResetContentStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveResetContentStatus', () => {
+        test('passes when given status code 200 to 599 except 205', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 205) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveResetContentStatus();
+          }
+        });
+
+        test(`fails when response have status code 205`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 205,
+          });
+
+          try {
+            expect(response).not.toHaveResetContentStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveSeeOtherStatus.test.js
+++ b/test/matchers/status/specific/toHaveSeeOtherStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveSeeOtherStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveSeeOtherStatus });
+
+describe('(.not).toHaveSeeOtherStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveSeeOtherStatus', () => {
+        test('passes when response has status code SEE_OTHER (303)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 303,
+          });
+
+          expect(response).toHaveSeeOtherStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 303) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveSeeOtherStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveSeeOtherStatus', () => {
+        test('passes when given status code 200 to 599 except 303', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 303) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveSeeOtherStatus();
+          }
+        });
+
+        test(`fails when response have status code 303`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 303,
+          });
+
+          try {
+            expect(response).not.toHaveSeeOtherStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveServiceUnavailableStatus.test.js
+++ b/test/matchers/status/specific/toHaveServiceUnavailableStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveServiceUnavailableStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveServiceUnavailableStatus });
+
+describe('(.not).toHaveServiceUnavailableStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveServiceUnavailableStatus', () => {
+        test('passes when response has status code SERVICE_UNAVAILABLE (503)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 503,
+          });
+
+          expect(response).toHaveServiceUnavailableStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 503) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveServiceUnavailableStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveServiceUnavailableStatus', () => {
+        test('passes when given status code 200 to 599 except 503', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 503) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveServiceUnavailableStatus();
+          }
+        });
+
+        test(`fails when response have status code 503`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 503,
+          });
+
+          try {
+            expect(response).not.toHaveServiceUnavailableStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveSwitchingProtocolsStatus.test.js
+++ b/test/matchers/status/specific/toHaveSwitchingProtocolsStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveSwitchingProtocolsStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveSwitchingProtocolsStatus });
+
+describe('(.not).toHaveSwitchingProtocolsStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveSwitchingProtocolsStatus', () => {
+        test('passes when response has status code SWITCHING_PROTOCOLS (101)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 101,
+          });
+
+          expect(response).toHaveSwitchingProtocolsStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 101) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveSwitchingProtocolsStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveSwitchingProtocolsStatus', () => {
+        test('passes when given status code 200 to 599 except 101', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 101) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveSwitchingProtocolsStatus();
+          }
+        });
+
+        test(`fails when response have status code 101`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 101,
+          });
+
+          try {
+            expect(response).not.toHaveSwitchingProtocolsStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveTemporaryRedirectStatus.test.js
+++ b/test/matchers/status/specific/toHaveTemporaryRedirectStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveTemporaryRedirectStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveTemporaryRedirectStatus });
+
+describe('(.not).toHaveTemporaryRedirectStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveTemporaryRedirectStatus', () => {
+        test('passes when response has status code TEMPORARY_REDIRECT (307)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 307,
+          });
+
+          expect(response).toHaveTemporaryRedirectStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 307) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveTemporaryRedirectStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveTemporaryRedirectStatus', () => {
+        test('passes when given status code 200 to 599 except 307', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 307) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveTemporaryRedirectStatus();
+          }
+        });
+
+        test(`fails when response have status code 307`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 307,
+          });
+
+          try {
+            expect(response).not.toHaveTemporaryRedirectStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveTooManyRequestsStatus.test.js
+++ b/test/matchers/status/specific/toHaveTooManyRequestsStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveTooManyRequestsStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveTooManyRequestsStatus });
+
+describe('(.not).toHaveTooManyRequestsStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveTooManyRequestsStatus', () => {
+        test('passes when response has status code TOO_MANY_REQUESTS (429)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 429,
+          });
+
+          expect(response).toHaveTooManyRequestsStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 429) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveTooManyRequestsStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveTooManyRequestsStatus', () => {
+        test('passes when given status code 200 to 599 except 429', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 429) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveTooManyRequestsStatus();
+          }
+        });
+
+        test(`fails when response have status code 429`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 429,
+          });
+
+          try {
+            expect(response).not.toHaveTooManyRequestsStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveUnauthorizedStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnauthorizedStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveUnauthorizedStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveUnauthorizedStatus });
+
+describe('(.not).toHaveUnauthorizedStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveUnauthorizedStatus', () => {
+        test('passes when response has status code UNAUTHORIZED (401)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 401,
+          });
+
+          expect(response).toHaveUnauthorizedStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 401) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveUnauthorizedStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveUnauthorizedStatus', () => {
+        test('passes when given status code 200 to 599 except 401', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 401) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveUnauthorizedStatus();
+          }
+        });
+
+        test(`fails when response have status code 401`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 401,
+          });
+
+          try {
+            expect(response).not.toHaveUnauthorizedStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveUnavailableForLegalReasonsStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnavailableForLegalReasonsStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveUnavailableForLegalReasonsStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveUnavailableForLegalReasonsStatus });
+
+describe('(.not).toHaveUnavailableForLegalReasonsStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveUnavailableForLegalReasonsStatus', () => {
+        test('passes when response has status code UNAVAILABLE_FOR_LEGAL_REASONS (451)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 451,
+          });
+
+          expect(response).toHaveUnavailableForLegalReasonsStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 451) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveUnavailableForLegalReasonsStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveUnavailableForLegalReasonsStatus', () => {
+        test('passes when given status code 200 to 599 except 451', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 451) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveUnavailableForLegalReasonsStatus();
+          }
+        });
+
+        test(`fails when response have status code 451`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 451,
+          });
+
+          try {
+            expect(response).not.toHaveUnavailableForLegalReasonsStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveUnprocessableEntityStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnprocessableEntityStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveUnprocessableEntityStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveUnprocessableEntityStatus });
+
+describe('(.not).toHaveUnprocessableEntityStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveUnprocessableEntityStatus', () => {
+        test('passes when response has status code UNPROCESSABLE_ENTITY (422)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 422,
+          });
+
+          expect(response).toHaveUnprocessableEntityStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 422) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveUnprocessableEntityStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveUnprocessableEntityStatus', () => {
+        test('passes when given status code 200 to 599 except 422', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 422) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveUnprocessableEntityStatus();
+          }
+        });
+
+        test(`fails when response have status code 422`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 422,
+          });
+
+          try {
+            expect(response).not.toHaveUnprocessableEntityStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveUnsupportedMediaTypeStatus.test.js
+++ b/test/matchers/status/specific/toHaveUnsupportedMediaTypeStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveUnsupportedMediaTypeStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveUnsupportedMediaTypeStatus });
+
+describe('(.not).toHaveUnsupportedMediaTypeStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveUnsupportedMediaTypeStatus', () => {
+        test('passes when response has status code UNSUPPORTED_MEDIA_TYPE (415)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 415,
+          });
+
+          expect(response).toHaveUnsupportedMediaTypeStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 415) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveUnsupportedMediaTypeStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveUnsupportedMediaTypeStatus', () => {
+        test('passes when given status code 200 to 599 except 415', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 415) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveUnsupportedMediaTypeStatus();
+          }
+        });
+
+        test(`fails when response have status code 415`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 415,
+          });
+
+          try {
+            expect(response).not.toHaveUnsupportedMediaTypeStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveUpgradeRequiredStatus.test.js
+++ b/test/matchers/status/specific/toHaveUpgradeRequiredStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveUpgradeRequiredStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveUpgradeRequiredStatus });
+
+describe('(.not).toHaveUpgradeRequiredStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveUpgradeRequiredStatus', () => {
+        test('passes when response has status code UPGRADE_REQUIRED (426)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 426,
+          });
+
+          expect(response).toHaveUpgradeRequiredStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 426) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveUpgradeRequiredStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveUpgradeRequiredStatus', () => {
+        test('passes when given status code 200 to 599 except 426', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 426) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveUpgradeRequiredStatus();
+          }
+        });
+
+        test(`fails when response have status code 426`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 426,
+          });
+
+          try {
+            expect(response).not.toHaveUpgradeRequiredStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/test/matchers/status/specific/toHaveUseProxyStatus.test.js
+++ b/test/matchers/status/specific/toHaveUseProxyStatus.test.js
@@ -1,0 +1,89 @@
+const { toHaveUseProxyStatus } = require('../../../../src');
+const { describe, test, before } = require('node:test');
+const { buildServer } = require('../../../helpers/server-helper.js');
+const { expect } = require('expect');
+const { getServerUrl } = require('../../../helpers/server-helper');
+const { testClients } = require('../../../helpers/supported-clients');
+
+expect.extend({ toHaveUseProxyStatus });
+
+describe('(.not).toHaveUseProxyStatus', () => {
+  /**
+   * @type {string}
+   */
+  let apiUrl = getServerUrl();
+
+  before(async () => {
+    await buildServer();
+  });
+
+  for (const testClient of testClients) {
+    describe(`using ${testClient.name}`, () => {
+      describe('.toHaveUseProxyStatus', () => {
+        test('passes when response has status code USE_PROXY (305)', async () => {
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 305,
+          });
+
+          expect(response).toHaveUseProxyStatus();
+        });
+
+        describe('other statuses', function allTests() {
+          for (let status = 200; status <= 599; status++) {
+            if (status === 305) {
+              continue;
+            }
+            test(`fails when response have status code ${status}`, async (t) => {
+              // Should have the assert snapshot assertion
+              t.plan(1);
+
+              const response = await testClient.post(`${apiUrl}/status`, {
+                status,
+              });
+
+              try {
+                expect(response).toHaveUseProxyStatus();
+              } catch (e) {
+                t.assert.snapshot(e);
+              }
+            });
+          }
+        });
+      });
+
+      describe('.not.toHaveUseProxyStatus', () => {
+        test('passes when given status code 200 to 599 except 305', async () => {
+          for (let i = 200; i <= 599; i++) {
+            if (i === 305) {
+              continue;
+            }
+            const response = await testClient.post(
+              `${apiUrl}/status`,
+              {
+                status: i,
+              },
+              {},
+            );
+
+            expect(response).not.toHaveUseProxyStatus();
+          }
+        });
+
+        test(`fails when response have status code 305`, async (t) => {
+          // Should have the assert snapshot assertion
+          t.plan(1);
+
+          const response = await testClient.post(`${apiUrl}/status`, {
+            status: 305,
+          });
+
+          try {
+            expect(response).not.toHaveUseProxyStatus();
+          } catch (e) {
+            t.assert.snapshot(e);
+          }
+        });
+      });
+    });
+  }
+});

--- a/types-test/expect-type-tests/package.json
+++ b/types-test/expect-type-tests/package.json
@@ -11,7 +11,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.7.3",
-    "expect-axios-matchers": "../../"
+    "expect-http-client-matchers": "../../"
   },
   "devDependencies": {
     "expect": "^29.7.0",

--- a/types-test/expect-type-tests/setup.ts
+++ b/types-test/expect-type-tests/setup.ts
@@ -1,6 +1,6 @@
-import 'expect-axios-matchers/expect.d.ts';
+import 'expect-http-client-matchers/expect.d.ts';
 
 import expect from 'expect';
-import * as matchers from 'expect-axios-matchers';
+import * as matchers from 'expect-http-client-matchers';
 
 expect.extend(matchers);

--- a/types-test/expect-type-tests/types.test.ts
+++ b/types-test/expect-type-tests/types.test.ts
@@ -2,24 +2,189 @@ import axios from 'axios';
 import expect from 'expect';
 
 async function run() {
-  const req = await axios.get('http://example.com');
+  const res = await axios.get('http://example.com');
 
-  expect(req).toBeTruthy();
+  expect(res).toBeTruthy();
 
-  expect(req).toBeSuccessful();
-  expect(req).not.toBeSuccessful();
+  expect(res).toBeSuccessful();
+  expect(res).not.toBeSuccessful();
 
-  expect(req).toHave2xxStatus();
-  expect(req).not.toHave2xxStatus();
+  expect(res).toHave2xxStatus();
+  expect(res).not.toHave2xxStatus();
 
-  expect(req).toHave3xxStatus();
-  expect(req).not.toHave3xxStatus();
+  expect(res).toHave3xxStatus();
+  expect(res).not.toHave3xxStatus();
 
-  expect(req).toHave4xxStatus();
-  expect(req).not.toHave4xxStatus();
+  expect(res).toHave4xxStatus();
+  expect(res).not.toHave4xxStatus();
 
-  expect(req).toHave5xxStatus();
-  expect(req).not.toHave5xxStatus();
+  expect(res).toHave5xxStatus();
+  expect(res).not.toHave5xxStatus();
+
+  expect(res).toHaveSwitchingProtocolsStatus();
+  expect(res).not.toHaveSwitchingProtocolsStatus();
+
+  expect(res).toHaveOkStatus();
+  expect(res).not.toHaveOkStatus();
+
+  expect(res).toHaveCreatedStatus();
+  expect(res).not.toHaveCreatedStatus();
+
+  expect(res).toHaveAcceptedStatus();
+  expect(res).not.toHaveAcceptedStatus();
+
+  expect(res).toHaveNonAuthoritativeInformationStatus();
+  expect(res).not.toHaveNonAuthoritativeInformationStatus();
+
+  expect(res).toHaveNoContentStatus();
+  expect(res).not.toHaveNoContentStatus();
+
+  expect(res).toHaveResetContentStatus();
+  expect(res).not.toHaveResetContentStatus();
+
+  expect(res).toHavePartialContentStatus();
+  expect(res).not.toHavePartialContentStatus();
+
+  expect(res).toHaveMultiStatusStatus();
+  expect(res).not.toHaveMultiStatusStatus();
+
+  expect(res).toHaveMultipleChoicesStatus();
+  expect(res).not.toHaveMultipleChoicesStatus();
+
+  expect(res).toHaveMovedPermanentlyStatus();
+  expect(res).not.toHaveMovedPermanentlyStatus();
+
+  expect(res).toHaveMovedTemporarilyStatus();
+  expect(res).not.toHaveMovedTemporarilyStatus();
+
+  expect(res).toHaveSeeOtherStatus();
+  expect(res).not.toHaveSeeOtherStatus();
+
+  expect(res).toHaveNotModifiedStatus();
+  expect(res).not.toHaveNotModifiedStatus();
+
+  expect(res).toHaveUseProxyStatus();
+  expect(res).not.toHaveUseProxyStatus();
+
+  expect(res).toHaveTemporaryRedirectStatus();
+  expect(res).not.toHaveTemporaryRedirectStatus();
+
+  expect(res).toHavePermanentRedirectStatus();
+  expect(res).not.toHavePermanentRedirectStatus();
+
+  expect(res).toHaveBadRequestStatus();
+  expect(res).not.toHaveBadRequestStatus();
+
+  expect(res).toHaveUnauthorizedStatus();
+  expect(res).not.toHaveUnauthorizedStatus();
+
+  expect(res).toHavePaymentRequiredStatus();
+  expect(res).not.toHavePaymentRequiredStatus();
+
+  expect(res).toHaveForbiddenStatus();
+  expect(res).not.toHaveForbiddenStatus();
+
+  expect(res).toHaveNotFoundStatus();
+  expect(res).not.toHaveNotFoundStatus();
+
+  expect(res).toHaveMethodNotAllowedStatus();
+  expect(res).not.toHaveMethodNotAllowedStatus();
+
+  expect(res).toHaveNotAcceptableStatus();
+  expect(res).not.toHaveNotAcceptableStatus();
+
+  expect(res).toHaveProxyAuthenticationRequiredStatus();
+  expect(res).not.toHaveProxyAuthenticationRequiredStatus();
+
+  expect(res).toHaveRequestTimeoutStatus();
+  expect(res).not.toHaveRequestTimeoutStatus();
+
+  expect(res).toHaveConflictStatus();
+  expect(res).not.toHaveConflictStatus();
+
+  expect(res).toHaveGoneStatus();
+  expect(res).not.toHaveGoneStatus();
+
+  expect(res).toHaveLengthRequiredStatus();
+  expect(res).not.toHaveLengthRequiredStatus();
+
+  expect(res).toHavePreconditionFailedStatus();
+  expect(res).not.toHavePreconditionFailedStatus();
+
+  expect(res).toHaveRequestTooLongStatus();
+  expect(res).not.toHaveRequestTooLongStatus();
+
+  expect(res).toHaveRequestUriTooLongStatus();
+  expect(res).not.toHaveRequestUriTooLongStatus();
+
+  expect(res).toHaveUnsupportedMediaTypeStatus();
+  expect(res).not.toHaveUnsupportedMediaTypeStatus();
+
+  expect(res).toHaveRequestedRangeNotSatisfiableStatus();
+  expect(res).not.toHaveRequestedRangeNotSatisfiableStatus();
+
+  expect(res).toHaveExpectationFailedStatus();
+  expect(res).not.toHaveExpectationFailedStatus();
+
+  expect(res).toHaveImATeapotStatus();
+  expect(res).not.toHaveImATeapotStatus();
+
+  expect(res).toHaveInsufficientSpaceOnResourceStatus();
+  expect(res).not.toHaveInsufficientSpaceOnResourceStatus();
+
+  expect(res).toHaveMethodFailureStatus();
+  expect(res).not.toHaveMethodFailureStatus();
+
+  expect(res).toHaveMisdirectedRequestStatus();
+  expect(res).not.toHaveMisdirectedRequestStatus();
+
+  expect(res).toHaveUnprocessableEntityStatus();
+  expect(res).not.toHaveUnprocessableEntityStatus();
+
+  expect(res).toHaveLockedStatus();
+  expect(res).not.toHaveLockedStatus();
+
+  expect(res).toHaveFailedDependencyStatus();
+  expect(res).not.toHaveFailedDependencyStatus();
+
+  expect(res).toHaveUpgradeRequiredStatus();
+  expect(res).not.toHaveUpgradeRequiredStatus();
+
+  expect(res).toHavePreconditionRequiredStatus();
+  expect(res).not.toHavePreconditionRequiredStatus();
+
+  expect(res).toHaveTooManyRequestsStatus();
+  expect(res).not.toHaveTooManyRequestsStatus();
+
+  expect(res).toHaveRequestHeaderFieldsTooLargeStatus();
+  expect(res).not.toHaveRequestHeaderFieldsTooLargeStatus();
+
+  expect(res).toHaveUnavailableForLegalReasonsStatus();
+  expect(res).not.toHaveUnavailableForLegalReasonsStatus();
+
+  expect(res).toHaveInternalServerErrorStatus();
+  expect(res).not.toHaveInternalServerErrorStatus();
+
+  expect(res).toHaveNotImplementedStatus();
+  expect(res).not.toHaveNotImplementedStatus();
+
+  expect(res).toHaveBadGatewayStatus();
+  expect(res).not.toHaveBadGatewayStatus();
+
+  expect(res).toHaveServiceUnavailableStatus();
+  expect(res).not.toHaveServiceUnavailableStatus();
+
+  expect(res).toHaveGatewayTimeoutStatus();
+  expect(res).not.toHaveGatewayTimeoutStatus();
+
+  expect(res).toHaveHttpVersionNotSupportedStatus();
+  expect(res).not.toHaveHttpVersionNotSupportedStatus();
+
+  expect(res).toHaveInsufficientStorageStatus();
+  expect(res).not.toHaveInsufficientStorageStatus();
+
+  expect(res).toHaveNetworkAuthenticationRequiredStatus();
+  expect(res).not.toHaveNetworkAuthenticationRequiredStatus();
 }
 
 run();

--- a/types-test/jest-all-type-tests/package.json
+++ b/types-test/jest-all-type-tests/package.json
@@ -11,7 +11,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.7.3",
-    "expect-axios-matchers": "../../"
+    "expect-http-client-matchers": "../../"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/types-test/jest-all-type-tests/setup.ts
+++ b/types-test/jest-all-type-tests/setup.ts
@@ -1,3 +1,3 @@
-import 'expect-axios-matchers/jest.d.ts';
+import 'expect-http-client-matchers/jest.d.ts';
 
-import 'expect-axios-matchers/all';
+import 'expect-http-client-matchers/all';

--- a/types-test/jest-all-type-tests/types.test.ts
+++ b/types-test/jest-all-type-tests/types.test.ts
@@ -1,24 +1,190 @@
 import axios from 'axios';
+import expect from 'expect';
 
 async function run() {
-  const req = await axios.get('http://example.com');
+  const res = await axios.get('http://example.com');
 
-  expect(req).toBeTruthy();
+  expect(res).toBeTruthy();
 
-  expect(req).toBeSuccessful();
-  expect(req).not.toBeSuccessful();
+  expect(res).toBeSuccessful();
+  expect(res).not.toBeSuccessful();
 
-  expect(req).toHave2xxStatus();
-  expect(req).not.toHave2xxStatus();
+  expect(res).toHave2xxStatus();
+  expect(res).not.toHave2xxStatus();
 
-  expect(req).toHave3xxStatus();
-  expect(req).not.toHave3xxStatus();
+  expect(res).toHave3xxStatus();
+  expect(res).not.toHave3xxStatus();
 
-  expect(req).toHave4xxStatus();
-  expect(req).not.toHave4xxStatus();
+  expect(res).toHave4xxStatus();
+  expect(res).not.toHave4xxStatus();
 
-  expect(req).toHave5xxStatus();
-  expect(req).not.toHave5xxStatus();
+  expect(res).toHave5xxStatus();
+  expect(res).not.toHave5xxStatus();
+
+  expect(res).toHaveSwitchingProtocolsStatus();
+  expect(res).not.toHaveSwitchingProtocolsStatus();
+
+  expect(res).toHaveOkStatus();
+  expect(res).not.toHaveOkStatus();
+
+  expect(res).toHaveCreatedStatus();
+  expect(res).not.toHaveCreatedStatus();
+
+  expect(res).toHaveAcceptedStatus();
+  expect(res).not.toHaveAcceptedStatus();
+
+  expect(res).toHaveNonAuthoritativeInformationStatus();
+  expect(res).not.toHaveNonAuthoritativeInformationStatus();
+
+  expect(res).toHaveNoContentStatus();
+  expect(res).not.toHaveNoContentStatus();
+
+  expect(res).toHaveResetContentStatus();
+  expect(res).not.toHaveResetContentStatus();
+
+  expect(res).toHavePartialContentStatus();
+  expect(res).not.toHavePartialContentStatus();
+
+  expect(res).toHaveMultiStatusStatus();
+  expect(res).not.toHaveMultiStatusStatus();
+
+  expect(res).toHaveMultipleChoicesStatus();
+  expect(res).not.toHaveMultipleChoicesStatus();
+
+  expect(res).toHaveMovedPermanentlyStatus();
+  expect(res).not.toHaveMovedPermanentlyStatus();
+
+  expect(res).toHaveMovedTemporarilyStatus();
+  expect(res).not.toHaveMovedTemporarilyStatus();
+
+  expect(res).toHaveSeeOtherStatus();
+  expect(res).not.toHaveSeeOtherStatus();
+
+  expect(res).toHaveNotModifiedStatus();
+  expect(res).not.toHaveNotModifiedStatus();
+
+  expect(res).toHaveUseProxyStatus();
+  expect(res).not.toHaveUseProxyStatus();
+
+  expect(res).toHaveTemporaryRedirectStatus();
+  expect(res).not.toHaveTemporaryRedirectStatus();
+
+  expect(res).toHavePermanentRedirectStatus();
+  expect(res).not.toHavePermanentRedirectStatus();
+
+  expect(res).toHaveBadRequestStatus();
+  expect(res).not.toHaveBadRequestStatus();
+
+  expect(res).toHaveUnauthorizedStatus();
+  expect(res).not.toHaveUnauthorizedStatus();
+
+  expect(res).toHavePaymentRequiredStatus();
+  expect(res).not.toHavePaymentRequiredStatus();
+
+  expect(res).toHaveForbiddenStatus();
+  expect(res).not.toHaveForbiddenStatus();
+
+  expect(res).toHaveNotFoundStatus();
+  expect(res).not.toHaveNotFoundStatus();
+
+  expect(res).toHaveMethodNotAllowedStatus();
+  expect(res).not.toHaveMethodNotAllowedStatus();
+
+  expect(res).toHaveNotAcceptableStatus();
+  expect(res).not.toHaveNotAcceptableStatus();
+
+  expect(res).toHaveProxyAuthenticationRequiredStatus();
+  expect(res).not.toHaveProxyAuthenticationRequiredStatus();
+
+  expect(res).toHaveRequestTimeoutStatus();
+  expect(res).not.toHaveRequestTimeoutStatus();
+
+  expect(res).toHaveConflictStatus();
+  expect(res).not.toHaveConflictStatus();
+
+  expect(res).toHaveGoneStatus();
+  expect(res).not.toHaveGoneStatus();
+
+  expect(res).toHaveLengthRequiredStatus();
+  expect(res).not.toHaveLengthRequiredStatus();
+
+  expect(res).toHavePreconditionFailedStatus();
+  expect(res).not.toHavePreconditionFailedStatus();
+
+  expect(res).toHaveRequestTooLongStatus();
+  expect(res).not.toHaveRequestTooLongStatus();
+
+  expect(res).toHaveRequestUriTooLongStatus();
+  expect(res).not.toHaveRequestUriTooLongStatus();
+
+  expect(res).toHaveUnsupportedMediaTypeStatus();
+  expect(res).not.toHaveUnsupportedMediaTypeStatus();
+
+  expect(res).toHaveRequestedRangeNotSatisfiableStatus();
+  expect(res).not.toHaveRequestedRangeNotSatisfiableStatus();
+
+  expect(res).toHaveExpectationFailedStatus();
+  expect(res).not.toHaveExpectationFailedStatus();
+
+  expect(res).toHaveImATeapotStatus();
+  expect(res).not.toHaveImATeapotStatus();
+
+  expect(res).toHaveInsufficientSpaceOnResourceStatus();
+  expect(res).not.toHaveInsufficientSpaceOnResourceStatus();
+
+  expect(res).toHaveMethodFailureStatus();
+  expect(res).not.toHaveMethodFailureStatus();
+
+  expect(res).toHaveMisdirectedRequestStatus();
+  expect(res).not.toHaveMisdirectedRequestStatus();
+
+  expect(res).toHaveUnprocessableEntityStatus();
+  expect(res).not.toHaveUnprocessableEntityStatus();
+
+  expect(res).toHaveLockedStatus();
+  expect(res).not.toHaveLockedStatus();
+
+  expect(res).toHaveFailedDependencyStatus();
+  expect(res).not.toHaveFailedDependencyStatus();
+
+  expect(res).toHaveUpgradeRequiredStatus();
+  expect(res).not.toHaveUpgradeRequiredStatus();
+
+  expect(res).toHavePreconditionRequiredStatus();
+  expect(res).not.toHavePreconditionRequiredStatus();
+
+  expect(res).toHaveTooManyRequestsStatus();
+  expect(res).not.toHaveTooManyRequestsStatus();
+
+  expect(res).toHaveRequestHeaderFieldsTooLargeStatus();
+  expect(res).not.toHaveRequestHeaderFieldsTooLargeStatus();
+
+  expect(res).toHaveUnavailableForLegalReasonsStatus();
+  expect(res).not.toHaveUnavailableForLegalReasonsStatus();
+
+  expect(res).toHaveInternalServerErrorStatus();
+  expect(res).not.toHaveInternalServerErrorStatus();
+
+  expect(res).toHaveNotImplementedStatus();
+  expect(res).not.toHaveNotImplementedStatus();
+
+  expect(res).toHaveBadGatewayStatus();
+  expect(res).not.toHaveBadGatewayStatus();
+
+  expect(res).toHaveServiceUnavailableStatus();
+  expect(res).not.toHaveServiceUnavailableStatus();
+
+  expect(res).toHaveGatewayTimeoutStatus();
+  expect(res).not.toHaveGatewayTimeoutStatus();
+
+  expect(res).toHaveHttpVersionNotSupportedStatus();
+  expect(res).not.toHaveHttpVersionNotSupportedStatus();
+
+  expect(res).toHaveInsufficientStorageStatus();
+  expect(res).not.toHaveInsufficientStorageStatus();
+
+  expect(res).toHaveNetworkAuthenticationRequiredStatus();
+  expect(res).not.toHaveNetworkAuthenticationRequiredStatus();
 }
 
 run();

--- a/types-test/jest-partial-type-tests/package.json
+++ b/types-test/jest-partial-type-tests/package.json
@@ -11,7 +11,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.7.3",
-    "expect-axios-matchers": "../../"
+    "expect-http-client-matchers": "../../"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/types-test/jest-partial-type-tests/setup.ts
+++ b/types-test/jest-partial-type-tests/setup.ts
@@ -1,6 +1,6 @@
-import 'expect-axios-matchers/jest.d.ts';
+import 'expect-http-client-matchers/jest.d.ts';
 
-import { toBeSuccessful } from 'expect-axios-matchers';
+import { toBeSuccessful } from 'expect-http-client-matchers';
 
 expect.extend({
   toBeSuccessful,

--- a/types-test/jest-partial-type-tests/types.test.ts
+++ b/types-test/jest-partial-type-tests/types.test.ts
@@ -1,24 +1,190 @@
 import axios from 'axios';
+import expect from 'expect';
 
 async function run() {
-  const req = await axios.get('http://example.com');
+  const res = await axios.get('http://example.com');
 
-  expect(req).toBeTruthy();
+  expect(res).toBeTruthy();
 
-  expect(req).toBeSuccessful();
-  expect(req).not.toBeSuccessful();
+  expect(res).toBeSuccessful();
+  expect(res).not.toBeSuccessful();
 
-  expect(req).toHave2xxStatus();
-  expect(req).not.toHave2xxStatus();
+  expect(res).toHave2xxStatus();
+  expect(res).not.toHave2xxStatus();
 
-  expect(req).toHave3xxStatus();
-  expect(req).not.toHave3xxStatus();
+  expect(res).toHave3xxStatus();
+  expect(res).not.toHave3xxStatus();
 
-  expect(req).toHave4xxStatus();
-  expect(req).not.toHave4xxStatus();
+  expect(res).toHave4xxStatus();
+  expect(res).not.toHave4xxStatus();
 
-  expect(req).toHave5xxStatus();
-  expect(req).not.toHave5xxStatus();
+  expect(res).toHave5xxStatus();
+  expect(res).not.toHave5xxStatus();
+
+  expect(res).toHaveSwitchingProtocolsStatus();
+  expect(res).not.toHaveSwitchingProtocolsStatus();
+
+  expect(res).toHaveOkStatus();
+  expect(res).not.toHaveOkStatus();
+
+  expect(res).toHaveCreatedStatus();
+  expect(res).not.toHaveCreatedStatus();
+
+  expect(res).toHaveAcceptedStatus();
+  expect(res).not.toHaveAcceptedStatus();
+
+  expect(res).toHaveNonAuthoritativeInformationStatus();
+  expect(res).not.toHaveNonAuthoritativeInformationStatus();
+
+  expect(res).toHaveNoContentStatus();
+  expect(res).not.toHaveNoContentStatus();
+
+  expect(res).toHaveResetContentStatus();
+  expect(res).not.toHaveResetContentStatus();
+
+  expect(res).toHavePartialContentStatus();
+  expect(res).not.toHavePartialContentStatus();
+
+  expect(res).toHaveMultiStatusStatus();
+  expect(res).not.toHaveMultiStatusStatus();
+
+  expect(res).toHaveMultipleChoicesStatus();
+  expect(res).not.toHaveMultipleChoicesStatus();
+
+  expect(res).toHaveMovedPermanentlyStatus();
+  expect(res).not.toHaveMovedPermanentlyStatus();
+
+  expect(res).toHaveMovedTemporarilyStatus();
+  expect(res).not.toHaveMovedTemporarilyStatus();
+
+  expect(res).toHaveSeeOtherStatus();
+  expect(res).not.toHaveSeeOtherStatus();
+
+  expect(res).toHaveNotModifiedStatus();
+  expect(res).not.toHaveNotModifiedStatus();
+
+  expect(res).toHaveUseProxyStatus();
+  expect(res).not.toHaveUseProxyStatus();
+
+  expect(res).toHaveTemporaryRedirectStatus();
+  expect(res).not.toHaveTemporaryRedirectStatus();
+
+  expect(res).toHavePermanentRedirectStatus();
+  expect(res).not.toHavePermanentRedirectStatus();
+
+  expect(res).toHaveBadRequestStatus();
+  expect(res).not.toHaveBadRequestStatus();
+
+  expect(res).toHaveUnauthorizedStatus();
+  expect(res).not.toHaveUnauthorizedStatus();
+
+  expect(res).toHavePaymentRequiredStatus();
+  expect(res).not.toHavePaymentRequiredStatus();
+
+  expect(res).toHaveForbiddenStatus();
+  expect(res).not.toHaveForbiddenStatus();
+
+  expect(res).toHaveNotFoundStatus();
+  expect(res).not.toHaveNotFoundStatus();
+
+  expect(res).toHaveMethodNotAllowedStatus();
+  expect(res).not.toHaveMethodNotAllowedStatus();
+
+  expect(res).toHaveNotAcceptableStatus();
+  expect(res).not.toHaveNotAcceptableStatus();
+
+  expect(res).toHaveProxyAuthenticationRequiredStatus();
+  expect(res).not.toHaveProxyAuthenticationRequiredStatus();
+
+  expect(res).toHaveRequestTimeoutStatus();
+  expect(res).not.toHaveRequestTimeoutStatus();
+
+  expect(res).toHaveConflictStatus();
+  expect(res).not.toHaveConflictStatus();
+
+  expect(res).toHaveGoneStatus();
+  expect(res).not.toHaveGoneStatus();
+
+  expect(res).toHaveLengthRequiredStatus();
+  expect(res).not.toHaveLengthRequiredStatus();
+
+  expect(res).toHavePreconditionFailedStatus();
+  expect(res).not.toHavePreconditionFailedStatus();
+
+  expect(res).toHaveRequestTooLongStatus();
+  expect(res).not.toHaveRequestTooLongStatus();
+
+  expect(res).toHaveRequestUriTooLongStatus();
+  expect(res).not.toHaveRequestUriTooLongStatus();
+
+  expect(res).toHaveUnsupportedMediaTypeStatus();
+  expect(res).not.toHaveUnsupportedMediaTypeStatus();
+
+  expect(res).toHaveRequestedRangeNotSatisfiableStatus();
+  expect(res).not.toHaveRequestedRangeNotSatisfiableStatus();
+
+  expect(res).toHaveExpectationFailedStatus();
+  expect(res).not.toHaveExpectationFailedStatus();
+
+  expect(res).toHaveImATeapotStatus();
+  expect(res).not.toHaveImATeapotStatus();
+
+  expect(res).toHaveInsufficientSpaceOnResourceStatus();
+  expect(res).not.toHaveInsufficientSpaceOnResourceStatus();
+
+  expect(res).toHaveMethodFailureStatus();
+  expect(res).not.toHaveMethodFailureStatus();
+
+  expect(res).toHaveMisdirectedRequestStatus();
+  expect(res).not.toHaveMisdirectedRequestStatus();
+
+  expect(res).toHaveUnprocessableEntityStatus();
+  expect(res).not.toHaveUnprocessableEntityStatus();
+
+  expect(res).toHaveLockedStatus();
+  expect(res).not.toHaveLockedStatus();
+
+  expect(res).toHaveFailedDependencyStatus();
+  expect(res).not.toHaveFailedDependencyStatus();
+
+  expect(res).toHaveUpgradeRequiredStatus();
+  expect(res).not.toHaveUpgradeRequiredStatus();
+
+  expect(res).toHavePreconditionRequiredStatus();
+  expect(res).not.toHavePreconditionRequiredStatus();
+
+  expect(res).toHaveTooManyRequestsStatus();
+  expect(res).not.toHaveTooManyRequestsStatus();
+
+  expect(res).toHaveRequestHeaderFieldsTooLargeStatus();
+  expect(res).not.toHaveRequestHeaderFieldsTooLargeStatus();
+
+  expect(res).toHaveUnavailableForLegalReasonsStatus();
+  expect(res).not.toHaveUnavailableForLegalReasonsStatus();
+
+  expect(res).toHaveInternalServerErrorStatus();
+  expect(res).not.toHaveInternalServerErrorStatus();
+
+  expect(res).toHaveNotImplementedStatus();
+  expect(res).not.toHaveNotImplementedStatus();
+
+  expect(res).toHaveBadGatewayStatus();
+  expect(res).not.toHaveBadGatewayStatus();
+
+  expect(res).toHaveServiceUnavailableStatus();
+  expect(res).not.toHaveServiceUnavailableStatus();
+
+  expect(res).toHaveGatewayTimeoutStatus();
+  expect(res).not.toHaveGatewayTimeoutStatus();
+
+  expect(res).toHaveHttpVersionNotSupportedStatus();
+  expect(res).not.toHaveHttpVersionNotSupportedStatus();
+
+  expect(res).toHaveInsufficientStorageStatus();
+  expect(res).not.toHaveInsufficientStorageStatus();
+
+  expect(res).toHaveNetworkAuthenticationRequiredStatus();
+  expect(res).not.toHaveNetworkAuthenticationRequiredStatus();
 }
 
 run();

--- a/types-test/vitest-all-type-tests/package.json
+++ b/types-test/vitest-all-type-tests/package.json
@@ -11,7 +11,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.7.3",
-    "expect-axios-matchers": "../../"
+    "expect-http-client-matchers": "../../"
   },
   "devDependencies": {
     "typescript": "^5.5.4",

--- a/types-test/vitest-all-type-tests/setup.ts
+++ b/types-test/vitest-all-type-tests/setup.ts
@@ -1,3 +1,3 @@
-import 'expect-axios-matchers/vitest.d.ts';
+import 'expect-http-client-matchers/vitest.d.ts';
 
-import 'expect-axios-matchers/all';
+import 'expect-http-client-matchers/all';

--- a/types-test/vitest-all-type-tests/types.test.ts
+++ b/types-test/vitest-all-type-tests/types.test.ts
@@ -1,24 +1,190 @@
 import axios from 'axios';
+import expect from 'expect';
 
 async function run() {
-  const req = await axios.get('http://example.com');
+  const res = await axios.get('http://example.com');
 
-  expect(req).toBeTruthy();
+  expect(res).toBeTruthy();
 
-  expect(req).toBeSuccessful();
-  expect(req).not.toBeSuccessful();
+  expect(res).toBeSuccessful();
+  expect(res).not.toBeSuccessful();
 
-  expect(req).toHave2xxStatus();
-  expect(req).not.toHave2xxStatus();
+  expect(res).toHave2xxStatus();
+  expect(res).not.toHave2xxStatus();
 
-  expect(req).toHave3xxStatus();
-  expect(req).not.toHave3xxStatus();
+  expect(res).toHave3xxStatus();
+  expect(res).not.toHave3xxStatus();
 
-  expect(req).toHave4xxStatus();
-  expect(req).not.toHave4xxStatus();
+  expect(res).toHave4xxStatus();
+  expect(res).not.toHave4xxStatus();
 
-  expect(req).toHave5xxStatus();
-  expect(req).not.toHave5xxStatus();
+  expect(res).toHave5xxStatus();
+  expect(res).not.toHave5xxStatus();
+
+  expect(res).toHaveSwitchingProtocolsStatus();
+  expect(res).not.toHaveSwitchingProtocolsStatus();
+
+  expect(res).toHaveOkStatus();
+  expect(res).not.toHaveOkStatus();
+
+  expect(res).toHaveCreatedStatus();
+  expect(res).not.toHaveCreatedStatus();
+
+  expect(res).toHaveAcceptedStatus();
+  expect(res).not.toHaveAcceptedStatus();
+
+  expect(res).toHaveNonAuthoritativeInformationStatus();
+  expect(res).not.toHaveNonAuthoritativeInformationStatus();
+
+  expect(res).toHaveNoContentStatus();
+  expect(res).not.toHaveNoContentStatus();
+
+  expect(res).toHaveResetContentStatus();
+  expect(res).not.toHaveResetContentStatus();
+
+  expect(res).toHavePartialContentStatus();
+  expect(res).not.toHavePartialContentStatus();
+
+  expect(res).toHaveMultiStatusStatus();
+  expect(res).not.toHaveMultiStatusStatus();
+
+  expect(res).toHaveMultipleChoicesStatus();
+  expect(res).not.toHaveMultipleChoicesStatus();
+
+  expect(res).toHaveMovedPermanentlyStatus();
+  expect(res).not.toHaveMovedPermanentlyStatus();
+
+  expect(res).toHaveMovedTemporarilyStatus();
+  expect(res).not.toHaveMovedTemporarilyStatus();
+
+  expect(res).toHaveSeeOtherStatus();
+  expect(res).not.toHaveSeeOtherStatus();
+
+  expect(res).toHaveNotModifiedStatus();
+  expect(res).not.toHaveNotModifiedStatus();
+
+  expect(res).toHaveUseProxyStatus();
+  expect(res).not.toHaveUseProxyStatus();
+
+  expect(res).toHaveTemporaryRedirectStatus();
+  expect(res).not.toHaveTemporaryRedirectStatus();
+
+  expect(res).toHavePermanentRedirectStatus();
+  expect(res).not.toHavePermanentRedirectStatus();
+
+  expect(res).toHaveBadRequestStatus();
+  expect(res).not.toHaveBadRequestStatus();
+
+  expect(res).toHaveUnauthorizedStatus();
+  expect(res).not.toHaveUnauthorizedStatus();
+
+  expect(res).toHavePaymentRequiredStatus();
+  expect(res).not.toHavePaymentRequiredStatus();
+
+  expect(res).toHaveForbiddenStatus();
+  expect(res).not.toHaveForbiddenStatus();
+
+  expect(res).toHaveNotFoundStatus();
+  expect(res).not.toHaveNotFoundStatus();
+
+  expect(res).toHaveMethodNotAllowedStatus();
+  expect(res).not.toHaveMethodNotAllowedStatus();
+
+  expect(res).toHaveNotAcceptableStatus();
+  expect(res).not.toHaveNotAcceptableStatus();
+
+  expect(res).toHaveProxyAuthenticationRequiredStatus();
+  expect(res).not.toHaveProxyAuthenticationRequiredStatus();
+
+  expect(res).toHaveRequestTimeoutStatus();
+  expect(res).not.toHaveRequestTimeoutStatus();
+
+  expect(res).toHaveConflictStatus();
+  expect(res).not.toHaveConflictStatus();
+
+  expect(res).toHaveGoneStatus();
+  expect(res).not.toHaveGoneStatus();
+
+  expect(res).toHaveLengthRequiredStatus();
+  expect(res).not.toHaveLengthRequiredStatus();
+
+  expect(res).toHavePreconditionFailedStatus();
+  expect(res).not.toHavePreconditionFailedStatus();
+
+  expect(res).toHaveRequestTooLongStatus();
+  expect(res).not.toHaveRequestTooLongStatus();
+
+  expect(res).toHaveRequestUriTooLongStatus();
+  expect(res).not.toHaveRequestUriTooLongStatus();
+
+  expect(res).toHaveUnsupportedMediaTypeStatus();
+  expect(res).not.toHaveUnsupportedMediaTypeStatus();
+
+  expect(res).toHaveRequestedRangeNotSatisfiableStatus();
+  expect(res).not.toHaveRequestedRangeNotSatisfiableStatus();
+
+  expect(res).toHaveExpectationFailedStatus();
+  expect(res).not.toHaveExpectationFailedStatus();
+
+  expect(res).toHaveImATeapotStatus();
+  expect(res).not.toHaveImATeapotStatus();
+
+  expect(res).toHaveInsufficientSpaceOnResourceStatus();
+  expect(res).not.toHaveInsufficientSpaceOnResourceStatus();
+
+  expect(res).toHaveMethodFailureStatus();
+  expect(res).not.toHaveMethodFailureStatus();
+
+  expect(res).toHaveMisdirectedRequestStatus();
+  expect(res).not.toHaveMisdirectedRequestStatus();
+
+  expect(res).toHaveUnprocessableEntityStatus();
+  expect(res).not.toHaveUnprocessableEntityStatus();
+
+  expect(res).toHaveLockedStatus();
+  expect(res).not.toHaveLockedStatus();
+
+  expect(res).toHaveFailedDependencyStatus();
+  expect(res).not.toHaveFailedDependencyStatus();
+
+  expect(res).toHaveUpgradeRequiredStatus();
+  expect(res).not.toHaveUpgradeRequiredStatus();
+
+  expect(res).toHavePreconditionRequiredStatus();
+  expect(res).not.toHavePreconditionRequiredStatus();
+
+  expect(res).toHaveTooManyRequestsStatus();
+  expect(res).not.toHaveTooManyRequestsStatus();
+
+  expect(res).toHaveRequestHeaderFieldsTooLargeStatus();
+  expect(res).not.toHaveRequestHeaderFieldsTooLargeStatus();
+
+  expect(res).toHaveUnavailableForLegalReasonsStatus();
+  expect(res).not.toHaveUnavailableForLegalReasonsStatus();
+
+  expect(res).toHaveInternalServerErrorStatus();
+  expect(res).not.toHaveInternalServerErrorStatus();
+
+  expect(res).toHaveNotImplementedStatus();
+  expect(res).not.toHaveNotImplementedStatus();
+
+  expect(res).toHaveBadGatewayStatus();
+  expect(res).not.toHaveBadGatewayStatus();
+
+  expect(res).toHaveServiceUnavailableStatus();
+  expect(res).not.toHaveServiceUnavailableStatus();
+
+  expect(res).toHaveGatewayTimeoutStatus();
+  expect(res).not.toHaveGatewayTimeoutStatus();
+
+  expect(res).toHaveHttpVersionNotSupportedStatus();
+  expect(res).not.toHaveHttpVersionNotSupportedStatus();
+
+  expect(res).toHaveInsufficientStorageStatus();
+  expect(res).not.toHaveInsufficientStorageStatus();
+
+  expect(res).toHaveNetworkAuthenticationRequiredStatus();
+  expect(res).not.toHaveNetworkAuthenticationRequiredStatus();
 }
 
 run();

--- a/types-test/vitest-partial-type-tests/package.json
+++ b/types-test/vitest-partial-type-tests/package.json
@@ -11,7 +11,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.7.3",
-    "expect-axios-matchers": "../../"
+    "expect-http-client-matchers": "../../"
   },
   "devDependencies": {
     "typescript": "^5.5.4",

--- a/types-test/vitest-partial-type-tests/setup.ts
+++ b/types-test/vitest-partial-type-tests/setup.ts
@@ -1,6 +1,6 @@
-import 'expect-axios-matchers/vitest.d.ts';
+import 'expect-http-client-matchers/vitest.d.ts';
 
-import { toBeSuccessful } from 'expect-axios-matchers';
+import { toBeSuccessful } from 'expect-http-client-matchers';
 
 expect.extend({
   toBeSuccessful,

--- a/types-test/vitest-partial-type-tests/types.test.ts
+++ b/types-test/vitest-partial-type-tests/types.test.ts
@@ -1,24 +1,190 @@
 import axios from 'axios';
+import expect from 'expect';
 
 async function run() {
-  const req = await axios.get('http://example.com');
+  const res = await axios.get('http://example.com');
 
-  expect(req).toBeTruthy();
+  expect(res).toBeTruthy();
 
-  expect(req).toBeSuccessful();
-  expect(req).not.toBeSuccessful();
+  expect(res).toBeSuccessful();
+  expect(res).not.toBeSuccessful();
 
-  expect(req).toHave2xxStatus();
-  expect(req).not.toHave2xxStatus();
+  expect(res).toHave2xxStatus();
+  expect(res).not.toHave2xxStatus();
 
-  expect(req).toHave3xxStatus();
-  expect(req).not.toHave3xxStatus();
+  expect(res).toHave3xxStatus();
+  expect(res).not.toHave3xxStatus();
 
-  expect(req).toHave4xxStatus();
-  expect(req).not.toHave4xxStatus();
+  expect(res).toHave4xxStatus();
+  expect(res).not.toHave4xxStatus();
 
-  expect(req).toHave5xxStatus();
-  expect(req).not.toHave5xxStatus();
+  expect(res).toHave5xxStatus();
+  expect(res).not.toHave5xxStatus();
+
+  expect(res).toHaveSwitchingProtocolsStatus();
+  expect(res).not.toHaveSwitchingProtocolsStatus();
+
+  expect(res).toHaveOkStatus();
+  expect(res).not.toHaveOkStatus();
+
+  expect(res).toHaveCreatedStatus();
+  expect(res).not.toHaveCreatedStatus();
+
+  expect(res).toHaveAcceptedStatus();
+  expect(res).not.toHaveAcceptedStatus();
+
+  expect(res).toHaveNonAuthoritativeInformationStatus();
+  expect(res).not.toHaveNonAuthoritativeInformationStatus();
+
+  expect(res).toHaveNoContentStatus();
+  expect(res).not.toHaveNoContentStatus();
+
+  expect(res).toHaveResetContentStatus();
+  expect(res).not.toHaveResetContentStatus();
+
+  expect(res).toHavePartialContentStatus();
+  expect(res).not.toHavePartialContentStatus();
+
+  expect(res).toHaveMultiStatusStatus();
+  expect(res).not.toHaveMultiStatusStatus();
+
+  expect(res).toHaveMultipleChoicesStatus();
+  expect(res).not.toHaveMultipleChoicesStatus();
+
+  expect(res).toHaveMovedPermanentlyStatus();
+  expect(res).not.toHaveMovedPermanentlyStatus();
+
+  expect(res).toHaveMovedTemporarilyStatus();
+  expect(res).not.toHaveMovedTemporarilyStatus();
+
+  expect(res).toHaveSeeOtherStatus();
+  expect(res).not.toHaveSeeOtherStatus();
+
+  expect(res).toHaveNotModifiedStatus();
+  expect(res).not.toHaveNotModifiedStatus();
+
+  expect(res).toHaveUseProxyStatus();
+  expect(res).not.toHaveUseProxyStatus();
+
+  expect(res).toHaveTemporaryRedirectStatus();
+  expect(res).not.toHaveTemporaryRedirectStatus();
+
+  expect(res).toHavePermanentRedirectStatus();
+  expect(res).not.toHavePermanentRedirectStatus();
+
+  expect(res).toHaveBadRequestStatus();
+  expect(res).not.toHaveBadRequestStatus();
+
+  expect(res).toHaveUnauthorizedStatus();
+  expect(res).not.toHaveUnauthorizedStatus();
+
+  expect(res).toHavePaymentRequiredStatus();
+  expect(res).not.toHavePaymentRequiredStatus();
+
+  expect(res).toHaveForbiddenStatus();
+  expect(res).not.toHaveForbiddenStatus();
+
+  expect(res).toHaveNotFoundStatus();
+  expect(res).not.toHaveNotFoundStatus();
+
+  expect(res).toHaveMethodNotAllowedStatus();
+  expect(res).not.toHaveMethodNotAllowedStatus();
+
+  expect(res).toHaveNotAcceptableStatus();
+  expect(res).not.toHaveNotAcceptableStatus();
+
+  expect(res).toHaveProxyAuthenticationRequiredStatus();
+  expect(res).not.toHaveProxyAuthenticationRequiredStatus();
+
+  expect(res).toHaveRequestTimeoutStatus();
+  expect(res).not.toHaveRequestTimeoutStatus();
+
+  expect(res).toHaveConflictStatus();
+  expect(res).not.toHaveConflictStatus();
+
+  expect(res).toHaveGoneStatus();
+  expect(res).not.toHaveGoneStatus();
+
+  expect(res).toHaveLengthRequiredStatus();
+  expect(res).not.toHaveLengthRequiredStatus();
+
+  expect(res).toHavePreconditionFailedStatus();
+  expect(res).not.toHavePreconditionFailedStatus();
+
+  expect(res).toHaveRequestTooLongStatus();
+  expect(res).not.toHaveRequestTooLongStatus();
+
+  expect(res).toHaveRequestUriTooLongStatus();
+  expect(res).not.toHaveRequestUriTooLongStatus();
+
+  expect(res).toHaveUnsupportedMediaTypeStatus();
+  expect(res).not.toHaveUnsupportedMediaTypeStatus();
+
+  expect(res).toHaveRequestedRangeNotSatisfiableStatus();
+  expect(res).not.toHaveRequestedRangeNotSatisfiableStatus();
+
+  expect(res).toHaveExpectationFailedStatus();
+  expect(res).not.toHaveExpectationFailedStatus();
+
+  expect(res).toHaveImATeapotStatus();
+  expect(res).not.toHaveImATeapotStatus();
+
+  expect(res).toHaveInsufficientSpaceOnResourceStatus();
+  expect(res).not.toHaveInsufficientSpaceOnResourceStatus();
+
+  expect(res).toHaveMethodFailureStatus();
+  expect(res).not.toHaveMethodFailureStatus();
+
+  expect(res).toHaveMisdirectedRequestStatus();
+  expect(res).not.toHaveMisdirectedRequestStatus();
+
+  expect(res).toHaveUnprocessableEntityStatus();
+  expect(res).not.toHaveUnprocessableEntityStatus();
+
+  expect(res).toHaveLockedStatus();
+  expect(res).not.toHaveLockedStatus();
+
+  expect(res).toHaveFailedDependencyStatus();
+  expect(res).not.toHaveFailedDependencyStatus();
+
+  expect(res).toHaveUpgradeRequiredStatus();
+  expect(res).not.toHaveUpgradeRequiredStatus();
+
+  expect(res).toHavePreconditionRequiredStatus();
+  expect(res).not.toHavePreconditionRequiredStatus();
+
+  expect(res).toHaveTooManyRequestsStatus();
+  expect(res).not.toHaveTooManyRequestsStatus();
+
+  expect(res).toHaveRequestHeaderFieldsTooLargeStatus();
+  expect(res).not.toHaveRequestHeaderFieldsTooLargeStatus();
+
+  expect(res).toHaveUnavailableForLegalReasonsStatus();
+  expect(res).not.toHaveUnavailableForLegalReasonsStatus();
+
+  expect(res).toHaveInternalServerErrorStatus();
+  expect(res).not.toHaveInternalServerErrorStatus();
+
+  expect(res).toHaveNotImplementedStatus();
+  expect(res).not.toHaveNotImplementedStatus();
+
+  expect(res).toHaveBadGatewayStatus();
+  expect(res).not.toHaveBadGatewayStatus();
+
+  expect(res).toHaveServiceUnavailableStatus();
+  expect(res).not.toHaveServiceUnavailableStatus();
+
+  expect(res).toHaveGatewayTimeoutStatus();
+  expect(res).not.toHaveGatewayTimeoutStatus();
+
+  expect(res).toHaveHttpVersionNotSupportedStatus();
+  expect(res).not.toHaveHttpVersionNotSupportedStatus();
+
+  expect(res).toHaveInsufficientStorageStatus();
+  expect(res).not.toHaveInsufficientStorageStatus();
+
+  expect(res).toHaveNetworkAuthenticationRequiredStatus();
+  expect(res).not.toHaveNetworkAuthenticationRequiredStatus();
 }
 
 run();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'expect-axios-matchers' {
+declare module 'expect-http-client-matchers' {
   const matchers: import('./shared').CustomMatchers<any>;
   export = matchers;
 }

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -23,32 +23,587 @@ export interface CustomMatchers<R> extends Record<string, any> {
    * Use .toHave5xxStatus when checking if Axios response status code is between 500 and 599 included
    */
   toHave5xxStatus(): R;
+
+  /**
+   * Use .toHaveOkStatus when checking if http response status code is 200
+   */
+  toHaveOkStatus(): R;
+
+  /**
+   * Use .toHaveSwitchingProtocolsStatus when checking if HTTP response status code is 101
+   */
+  toHaveSwitchingProtocolsStatus(): R;
+
+  /**
+   * Use .toHaveOkStatus when checking if HTTP response status code is 200
+   */
+  toHaveOkStatus(): R;
+
+  /**
+   * Use .toHaveCreatedStatus when checking if HTTP response status code is 201
+   */
+  toHaveCreatedStatus(): R;
+
+  /**
+   * Use .toHaveAcceptedStatus when checking if HTTP response status code is 202
+   */
+  toHaveAcceptedStatus(): R;
+
+  /**
+   * Use .toHaveNonAuthoritativeInformationStatus when checking if HTTP response status code is 203
+   */
+  toHaveNonAuthoritativeInformationStatus(): R;
+
+  /**
+   * Use .toHaveNoContentStatus when checking if HTTP response status code is 204
+   */
+  toHaveNoContentStatus(): R;
+
+  /**
+   * Use .toHaveResetContentStatus when checking if HTTP response status code is 205
+   */
+  toHaveResetContentStatus(): R;
+
+  /**
+   * Use .toHavePartialContentStatus when checking if HTTP response status code is 206
+   */
+  toHavePartialContentStatus(): R;
+
+  /**
+   * Use .toHaveMultiStatusStatus when checking if HTTP response status code is 207
+   */
+  toHaveMultiStatusStatus(): R;
+
+  /**
+   * Use .toHaveMultipleChoicesStatus when checking if HTTP response status code is 300
+   */
+  toHaveMultipleChoicesStatus(): R;
+
+  /**
+   * Use .toHaveMovedPermanentlyStatus when checking if HTTP response status code is 301
+   */
+  toHaveMovedPermanentlyStatus(): R;
+
+  /**
+   * Use .toHaveMovedTemporarilyStatus when checking if HTTP response status code is 302
+   */
+  toHaveMovedTemporarilyStatus(): R;
+
+  /**
+   * Use .toHaveSeeOtherStatus when checking if HTTP response status code is 303
+   */
+  toHaveSeeOtherStatus(): R;
+
+  /**
+   * Use .toHaveNotModifiedStatus when checking if HTTP response status code is 304
+   */
+  toHaveNotModifiedStatus(): R;
+
+  /**
+   * Use .toHaveUseProxyStatus when checking if HTTP response status code is 305
+   */
+  toHaveUseProxyStatus(): R;
+
+  /**
+   * Use .toHaveTemporaryRedirectStatus when checking if HTTP response status code is 307
+   */
+  toHaveTemporaryRedirectStatus(): R;
+
+  /**
+   * Use .toHavePermanentRedirectStatus when checking if HTTP response status code is 308
+   */
+  toHavePermanentRedirectStatus(): R;
+
+  /**
+   * Use .toHaveBadRequestStatus when checking if HTTP response status code is 400
+   */
+  toHaveBadRequestStatus(): R;
+
+  /**
+   * Use .toHaveUnauthorizedStatus when checking if HTTP response status code is 401
+   */
+  toHaveUnauthorizedStatus(): R;
+
+  /**
+   * Use .toHavePaymentRequiredStatus when checking if HTTP response status code is 402
+   */
+  toHavePaymentRequiredStatus(): R;
+
+  /**
+   * Use .toHaveForbiddenStatus when checking if HTTP response status code is 403
+   */
+  toHaveForbiddenStatus(): R;
+
+  /**
+   * Use .toHaveNotFoundStatus when checking if HTTP response status code is 404
+   */
+  toHaveNotFoundStatus(): R;
+
+  /**
+   * Use .toHaveMethodNotAllowedStatus when checking if HTTP response status code is 405
+   */
+  toHaveMethodNotAllowedStatus(): R;
+
+  /**
+   * Use .toHaveNotAcceptableStatus when checking if HTTP response status code is 406
+   */
+  toHaveNotAcceptableStatus(): R;
+
+  /**
+   * Use .toHaveProxyAuthenticationRequiredStatus when checking if HTTP response status code is 407
+   */
+  toHaveProxyAuthenticationRequiredStatus(): R;
+
+  /**
+   * Use .toHaveRequestTimeoutStatus when checking if HTTP response status code is 408
+   */
+  toHaveRequestTimeoutStatus(): R;
+
+  /**
+   * Use .toHaveConflictStatus when checking if HTTP response status code is 409
+   */
+  toHaveConflictStatus(): R;
+
+  /**
+   * Use .toHaveGoneStatus when checking if HTTP response status code is 410
+   */
+  toHaveGoneStatus(): R;
+
+  /**
+   * Use .toHaveLengthRequiredStatus when checking if HTTP response status code is 411
+   */
+  toHaveLengthRequiredStatus(): R;
+
+  /**
+   * Use .toHavePreconditionFailedStatus when checking if HTTP response status code is 412
+   */
+  toHavePreconditionFailedStatus(): R;
+
+  /**
+   * Use .toHaveRequestTooLongStatus when checking if HTTP response status code is 413
+   */
+  toHaveRequestTooLongStatus(): R;
+
+  /**
+   * Use .toHaveRequestUriTooLongStatus when checking if HTTP response status code is 414
+   */
+  toHaveRequestUriTooLongStatus(): R;
+
+  /**
+   * Use .toHaveUnsupportedMediaTypeStatus when checking if HTTP response status code is 415
+   */
+  toHaveUnsupportedMediaTypeStatus(): R;
+
+  /**
+   * Use .toHaveRequestedRangeNotSatisfiableStatus when checking if HTTP response status code is 416
+   */
+  toHaveRequestedRangeNotSatisfiableStatus(): R;
+
+  /**
+   * Use .toHaveExpectationFailedStatus when checking if HTTP response status code is 417
+   */
+  toHaveExpectationFailedStatus(): R;
+
+  /**
+   * Use .toHaveImATeapotStatus when checking if HTTP response status code is 418
+   */
+  toHaveImATeapotStatus(): R;
+
+  /**
+   * Use .toHaveInsufficientSpaceOnResourceStatus when checking if HTTP response status code is 419
+   */
+  toHaveInsufficientSpaceOnResourceStatus(): R;
+
+  /**
+   * Use .toHaveMethodFailureStatus when checking if HTTP response status code is 420
+   */
+  toHaveMethodFailureStatus(): R;
+
+  /**
+   * Use .toHaveMisdirectedRequestStatus when checking if HTTP response status code is 421
+   */
+  toHaveMisdirectedRequestStatus(): R;
+
+  /**
+   * Use .toHaveUnprocessableEntityStatus when checking if HTTP response status code is 422
+   */
+  toHaveUnprocessableEntityStatus(): R;
+
+  /**
+   * Use .toHaveLockedStatus when checking if HTTP response status code is 423
+   */
+  toHaveLockedStatus(): R;
+
+  /**
+   * Use .toHaveFailedDependencyStatus when checking if HTTP response status code is 424
+   */
+  toHaveFailedDependencyStatus(): R;
+
+  /**
+   * Use .toHaveUpgradeRequiredStatus when checking if HTTP response status code is 426
+   */
+  toHaveUpgradeRequiredStatus(): R;
+
+  /**
+   * Use .toHavePreconditionRequiredStatus when checking if HTTP response status code is 428
+   */
+  toHavePreconditionRequiredStatus(): R;
+
+  /**
+   * Use .toHaveTooManyRequestsStatus when checking if HTTP response status code is 429
+   */
+  toHaveTooManyRequestsStatus(): R;
+
+  /**
+   * Use .toHaveRequestHeaderFieldsTooLargeStatus when checking if HTTP response status code is 431
+   */
+  toHaveRequestHeaderFieldsTooLargeStatus(): R;
+
+  /**
+   * Use .toHaveUnavailableForLegalReasonsStatus when checking if HTTP response status code is 451
+   */
+  toHaveUnavailableForLegalReasonsStatus(): R;
+
+  /**
+   * Use .toHaveInternalServerErrorStatus when checking if HTTP response status code is 500
+   */
+  toHaveInternalServerErrorStatus(): R;
+
+  /**
+   * Use .toHaveNotImplementedStatus when checking if HTTP response status code is 501
+   */
+  toHaveNotImplementedStatus(): R;
+
+  /**
+   * Use .toHaveBadGatewayStatus when checking if HTTP response status code is 502
+   */
+  toHaveBadGatewayStatus(): R;
+
+  /**
+   * Use .toHaveServiceUnavailableStatus when checking if HTTP response status code is 503
+   */
+  toHaveServiceUnavailableStatus(): R;
+
+  /**
+   * Use .toHaveGatewayTimeoutStatus when checking if HTTP response status code is 504
+   */
+  toHaveGatewayTimeoutStatus(): R;
+
+  /**
+   * Use .toHaveHttpVersionNotSupportedStatus when checking if HTTP response status code is 505
+   */
+  toHaveHttpVersionNotSupportedStatus(): R;
+
+  /**
+   * Use .toHaveInsufficientStorageStatus when checking if HTTP response status code is 507
+   */
+  toHaveInsufficientStorageStatus(): R;
+
+  /**
+   * Use .toHaveNetworkAuthenticationRequiredStatus when checking if HTTP response status code is 511
+   */
+  toHaveNetworkAuthenticationRequiredStatus(): R;
 }
 
 // noinspection JSUnusedGlobalSymbols
 export interface SharedMatchers<R> {
   /**
-   * Use .toBeSuccessful when checking if Axios response status code is between 200 and 299 included
+   * Use .toBeSuccessful when checking if HTTP response status code is between 200 and 299 included
    */
   toBeSuccessful(): R;
 
   /**
-   Use .toHave2xxStatus when checking if Axios response status code is between 200 and 299 included
+   Use .toHave2xxStatus when checking if HTTP response status code is between 200 and 299 included
    */
   toHave2xxStatus(): R;
 
   /**
-   * Use .toHave3xxStatus when checking if Axios response status code is between 300 and 399 included
+   * Use .toHave3xxStatus when checking if HTTP response status code is between 300 and 399 included
    */
   toHave3xxStatus(): R;
 
   /**
-   * Use .toHave4xxStatus when checking if Axios response status code is between 400 and 499 included
+   * Use .toHave4xxStatus when checking if HTTP response status code is between 400 and 499 included
    */
   toHave4xxStatus(): R;
 
   /**
-   * Use .toHave5xxStatus when checking if Axios response status code is between 500 and 599 included
+   * Use .toHave5xxStatus when checking if HTTP response status code is between 500 and 599 included
    */
   toHave5xxStatus(): R;
+
+  /**
+   * Use .toHaveSwitchingProtocolsStatus when checking if HTTP response status code is 101
+   */
+  toHaveSwitchingProtocolsStatus(): R;
+
+  /**
+   * Use .toHaveOkStatus when checking if HTTP response status code is 200
+   */
+  toHaveOkStatus(): R;
+
+  /**
+   * Use .toHaveCreatedStatus when checking if HTTP response status code is 201
+   */
+  toHaveCreatedStatus(): R;
+
+  /**
+   * Use .toHaveAcceptedStatus when checking if HTTP response status code is 202
+   */
+  toHaveAcceptedStatus(): R;
+
+  /**
+   * Use .toHaveNonAuthoritativeInformationStatus when checking if HTTP response status code is 203
+   */
+  toHaveNonAuthoritativeInformationStatus(): R;
+
+  /**
+   * Use .toHaveNoContentStatus when checking if HTTP response status code is 204
+   */
+  toHaveNoContentStatus(): R;
+
+  /**
+   * Use .toHaveResetContentStatus when checking if HTTP response status code is 205
+   */
+  toHaveResetContentStatus(): R;
+
+  /**
+   * Use .toHavePartialContentStatus when checking if HTTP response status code is 206
+   */
+  toHavePartialContentStatus(): R;
+
+  /**
+   * Use .toHaveMultiStatusStatus when checking if HTTP response status code is 207
+   */
+  toHaveMultiStatusStatus(): R;
+
+  /**
+   * Use .toHaveMultipleChoicesStatus when checking if HTTP response status code is 300
+   */
+  toHaveMultipleChoicesStatus(): R;
+
+  /**
+   * Use .toHaveMovedPermanentlyStatus when checking if HTTP response status code is 301
+   */
+  toHaveMovedPermanentlyStatus(): R;
+
+  /**
+   * Use .toHaveMovedTemporarilyStatus when checking if HTTP response status code is 302
+   */
+  toHaveMovedTemporarilyStatus(): R;
+
+  /**
+   * Use .toHaveSeeOtherStatus when checking if HTTP response status code is 303
+   */
+  toHaveSeeOtherStatus(): R;
+
+  /**
+   * Use .toHaveNotModifiedStatus when checking if HTTP response status code is 304
+   */
+  toHaveNotModifiedStatus(): R;
+
+  /**
+   * Use .toHaveUseProxyStatus when checking if HTTP response status code is 305
+   */
+  toHaveUseProxyStatus(): R;
+
+  /**
+   * Use .toHaveTemporaryRedirectStatus when checking if HTTP response status code is 307
+   */
+  toHaveTemporaryRedirectStatus(): R;
+
+  /**
+   * Use .toHavePermanentRedirectStatus when checking if HTTP response status code is 308
+   */
+  toHavePermanentRedirectStatus(): R;
+
+  /**
+   * Use .toHaveBadRequestStatus when checking if HTTP response status code is 400
+   */
+  toHaveBadRequestStatus(): R;
+
+  /**
+   * Use .toHaveUnauthorizedStatus when checking if HTTP response status code is 401
+   */
+  toHaveUnauthorizedStatus(): R;
+
+  /**
+   * Use .toHavePaymentRequiredStatus when checking if HTTP response status code is 402
+   */
+  toHavePaymentRequiredStatus(): R;
+
+  /**
+   * Use .toHaveForbiddenStatus when checking if HTTP response status code is 403
+   */
+  toHaveForbiddenStatus(): R;
+
+  /**
+   * Use .toHaveNotFoundStatus when checking if HTTP response status code is 404
+   */
+  toHaveNotFoundStatus(): R;
+
+  /**
+   * Use .toHaveMethodNotAllowedStatus when checking if HTTP response status code is 405
+   */
+  toHaveMethodNotAllowedStatus(): R;
+
+  /**
+   * Use .toHaveNotAcceptableStatus when checking if HTTP response status code is 406
+   */
+  toHaveNotAcceptableStatus(): R;
+
+  /**
+   * Use .toHaveProxyAuthenticationRequiredStatus when checking if HTTP response status code is 407
+   */
+  toHaveProxyAuthenticationRequiredStatus(): R;
+
+  /**
+   * Use .toHaveRequestTimeoutStatus when checking if HTTP response status code is 408
+   */
+  toHaveRequestTimeoutStatus(): R;
+
+  /**
+   * Use .toHaveConflictStatus when checking if HTTP response status code is 409
+   */
+  toHaveConflictStatus(): R;
+
+  /**
+   * Use .toHaveGoneStatus when checking if HTTP response status code is 410
+   */
+  toHaveGoneStatus(): R;
+
+  /**
+   * Use .toHaveLengthRequiredStatus when checking if HTTP response status code is 411
+   */
+  toHaveLengthRequiredStatus(): R;
+
+  /**
+   * Use .toHavePreconditionFailedStatus when checking if HTTP response status code is 412
+   */
+  toHavePreconditionFailedStatus(): R;
+
+  /**
+   * Use .toHaveRequestTooLongStatus when checking if HTTP response status code is 413
+   */
+  toHaveRequestTooLongStatus(): R;
+
+  /**
+   * Use .toHaveRequestUriTooLongStatus when checking if HTTP response status code is 414
+   */
+  toHaveRequestUriTooLongStatus(): R;
+
+  /**
+   * Use .toHaveUnsupportedMediaTypeStatus when checking if HTTP response status code is 415
+   */
+  toHaveUnsupportedMediaTypeStatus(): R;
+
+  /**
+   * Use .toHaveRequestedRangeNotSatisfiableStatus when checking if HTTP response status code is 416
+   */
+  toHaveRequestedRangeNotSatisfiableStatus(): R;
+
+  /**
+   * Use .toHaveExpectationFailedStatus when checking if HTTP response status code is 417
+   */
+  toHaveExpectationFailedStatus(): R;
+
+  /**
+   * Use .toHaveImATeapotStatus when checking if HTTP response status code is 418
+   */
+  toHaveImATeapotStatus(): R;
+
+  /**
+   * Use .toHaveInsufficientSpaceOnResourceStatus when checking if HTTP response status code is 419
+   */
+  toHaveInsufficientSpaceOnResourceStatus(): R;
+
+  /**
+   * Use .toHaveMethodFailureStatus when checking if HTTP response status code is 420
+   */
+  toHaveMethodFailureStatus(): R;
+
+  /**
+   * Use .toHaveMisdirectedRequestStatus when checking if HTTP response status code is 421
+   */
+  toHaveMisdirectedRequestStatus(): R;
+
+  /**
+   * Use .toHaveUnprocessableEntityStatus when checking if HTTP response status code is 422
+   */
+  toHaveUnprocessableEntityStatus(): R;
+
+  /**
+   * Use .toHaveLockedStatus when checking if HTTP response status code is 423
+   */
+  toHaveLockedStatus(): R;
+
+  /**
+   * Use .toHaveFailedDependencyStatus when checking if HTTP response status code is 424
+   */
+  toHaveFailedDependencyStatus(): R;
+
+  /**
+   * Use .toHaveUpgradeRequiredStatus when checking if HTTP response status code is 426
+   */
+  toHaveUpgradeRequiredStatus(): R;
+
+  /**
+   * Use .toHavePreconditionRequiredStatus when checking if HTTP response status code is 428
+   */
+  toHavePreconditionRequiredStatus(): R;
+
+  /**
+   * Use .toHaveTooManyRequestsStatus when checking if HTTP response status code is 429
+   */
+  toHaveTooManyRequestsStatus(): R;
+
+  /**
+   * Use .toHaveRequestHeaderFieldsTooLargeStatus when checking if HTTP response status code is 431
+   */
+  toHaveRequestHeaderFieldsTooLargeStatus(): R;
+
+  /**
+   * Use .toHaveUnavailableForLegalReasonsStatus when checking if HTTP response status code is 451
+   */
+  toHaveUnavailableForLegalReasonsStatus(): R;
+
+  /**
+   * Use .toHaveInternalServerErrorStatus when checking if HTTP response status code is 500
+   */
+  toHaveInternalServerErrorStatus(): R;
+
+  /**
+   * Use .toHaveNotImplementedStatus when checking if HTTP response status code is 501
+   */
+  toHaveNotImplementedStatus(): R;
+
+  /**
+   * Use .toHaveBadGatewayStatus when checking if HTTP response status code is 502
+   */
+  toHaveBadGatewayStatus(): R;
+
+  /**
+   * Use .toHaveServiceUnavailableStatus when checking if HTTP response status code is 503
+   */
+  toHaveServiceUnavailableStatus(): R;
+
+  /**
+   * Use .toHaveGatewayTimeoutStatus when checking if HTTP response status code is 504
+   */
+  toHaveGatewayTimeoutStatus(): R;
+
+  /**
+   * Use .toHaveHttpVersionNotSupportedStatus when checking if HTTP response status code is 505
+   */
+  toHaveHttpVersionNotSupportedStatus(): R;
+
+  /**
+   * Use .toHaveInsufficientStorageStatus when checking if HTTP response status code is 507
+   */
+  toHaveInsufficientStorageStatus(): R;
+
+  /**
+   * Use .toHaveNetworkAuthenticationRequiredStatus when checking if HTTP response status code is 511
+   */
+  toHaveNetworkAuthenticationRequiredStatus(): R;
 }


### PR DESCRIPTION

Added:
- `.toHaveSwitchingProtocolsStatus()`
- `.toHaveOkStatus()`
- `.toHaveCreatedStatus()`
- `.toHaveAcceptedStatus()`
- `.toHaveNonAuthoritativeInformationStatus()`
- `.toHaveNoContentStatus()`
- `.toHaveResetContentStatus()`
- `.toHavePartialContentStatus()`
- `.toHaveMultiStatusStatus()`
- `.toHaveMultipleChoicesStatus()`
- `.toHaveMovedPermanentlyStatus()`
- `.toHaveMovedTemporarilyStatus()`
- `.toHaveSeeOtherStatus()`
- `.toHaveNotModifiedStatus()`
- `.toHaveUseProxyStatus()`
- `.toHaveTemporaryRedirectStatus()`
- `.toHavePermanentRedirectStatus()`
- `.toHaveBadRequestStatus()`
- `.toHaveUnauthorizedStatus()`
- `.toHavePaymentRequiredStatus()`
- `.toHaveForbiddenStatus()`
- `.toHaveNotFoundStatus()`
- `.toHaveMethodNotAllowedStatus()`
- `.toHaveNotAcceptableStatus()`
- `.toHaveProxyAuthenticationRequiredStatus()`
- `.toHaveRequestTimeoutStatus()`
- `.toHaveConflictStatus()`
- `.toHaveGoneStatus()`
- `.toHaveLengthRequiredStatus()`
- `.toHavePreconditionFailedStatus()`
- `.toHaveRequestTooLongStatus()`
- `.toHaveRequestUriTooLongStatus()`
- `.toHaveUnsupportedMediaTypeStatus()`
- `.toHaveRequestedRangeNotSatisfiableStatus()`
- `.toHaveExpectationFailedStatus()`
- `.toHaveImATeapotStatus()`
- `.toHaveInsufficientSpaceOnResourceStatus()`
- `.toHaveMethodFailureStatus()`
- `.toHaveMisdirectedRequestStatus()`
- `.toHaveUnprocessableEntityStatus()`
- `.toHaveLockedStatus()`
- `.toHaveFailedDependencyStatus()`
- `.toHaveUpgradeRequiredStatus()`
- `.toHavePreconditionRequiredStatus()`
- `.toHaveTooManyRequestsStatus()`
- `.toHaveRequestHeaderFieldsTooLargeStatus()`
- `.toHaveUnavailableForLegalReasonsStatus()`
- `.toHaveInternalServerErrorStatus()`
- `.toHaveNotImplementedStatus()`
- `.toHaveBadGatewayStatus()`
- `.toHaveServiceUnavailableStatus()`
- `.toHaveGatewayTimeoutStatus()`
- `.toHaveHttpVersionNotSupportedStatus()`
- `.toHaveInsufficientStorageStatus()`
- `.toHaveNetworkAuthenticationRequiredStatus()`